### PR TITLE
#93 タグ一覧の2ページ目以降が表示されない問題の対応

### DIFF
--- a/src/main/java/org/support/project/knowledge/logic/TagLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/TagLogic.java
@@ -46,7 +46,7 @@ public class TagLogic {
 		if (loginedUser != null && loginedUser.isAdmin()) {
 			tags = tagsDao.selectWithKnowledgeCountAdmin(offset, limit);
 		} else {
-			tags = tagsDao.selectWithKnowledgeCount(userid, groups, offset * offset, limit);
+			tags = tagsDao.selectWithKnowledgeCount(userid, groups, offset, limit);
 		}
 		return tags;
 	}


### PR DESCRIPTION
#93 の問題を対応しました。
ご検討よろしくお願いします。

※Mac book el capitan上のtomcatで表示されるのを確認しました。