### PR TITLE
#99 各通知キュー登録時にnullチェックをするように

### DIFF
--- a/src/main/java/org/support/project/knowledge/bat/NotifyMailBat.java
+++ b/src/main/java/org/support/project/knowledge/bat/NotifyMailBat.java
@@ -63,11 +63,12 @@ public class NotifyMailBat extends AbstractBat {
 		
 		finishInfo();
 	}
-	
+
 	/**
 	 * 通知キューを処理して、メール送信テーブルにメール通知を登録する
 	 */
 	private void start() {
+		LOG.info("Notify process started.");
 		NotifyQueuesDao notifyQueuesDao = NotifyQueuesDao.get();
 		List<NotifyQueuesEntity> notifyQueuesEntities = notifyQueuesDao.selectAll();
 		for (NotifyQueuesEntity notifyQueuesEntity : notifyQueuesEntities) {
@@ -116,8 +117,17 @@ public class NotifyMailBat extends AbstractBat {
 	private void notifyLikeInsert(NotifyQueuesEntity notifyQueuesEntity) {
 		LikesDao likesDao = LikesDao.get();
 		LikesEntity like = likesDao.selectOnKey(notifyQueuesEntity.getId());
+		if (null == like) {
+			LOG.warn("Like record not found. id: " + notifyQueuesEntity.getId());
+			return;
+		}
+
 		KnowledgesDao knowledgesDao = KnowledgesDao.get();
 		KnowledgesEntity knowledge = knowledgesDao.selectOnKey(like.getKnowledgeId());
+		if (null == knowledge) {
+			LOG.warn("Knowledge record not found. id: " + notifyQueuesEntity.getId());
+			return;
+		}
 		
 		if (sendedLikeKnowledgeIds.contains(knowledge.getKnowledgeId())) {
 			if (LOG.isDebugEnabled()) {
@@ -196,9 +206,18 @@ public class NotifyMailBat extends AbstractBat {
 	private void notifyCommentInsert(NotifyQueuesEntity notifyQueuesEntity) {
 		CommentsDao commentsDao = CommentsDao.get();
 		CommentsEntity comment = commentsDao.selectOnKey(notifyQueuesEntity.getId());
+		if (null == comment) {
+			LOG.warn("Comment record not found. id: " + notifyQueuesEntity.getId());
+			return;
+		}
+
 		KnowledgesDao knowledgesDao = KnowledgesDao.get();
 		KnowledgesEntity knowledge = knowledgesDao.selectOnKey(comment.getKnowledgeId());
-		
+		if (null == knowledge) {
+			LOG.warn("Knowledge record not found. id: " + notifyQueuesEntity.getId());
+			return;
+		}
+
 		if (sendedCommentKnowledgeIds.contains(knowledge.getKnowledgeId())) {
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Knowledge [" + knowledge.getKnowledgeId() + "] ");
@@ -326,6 +345,11 @@ public class NotifyMailBat extends AbstractBat {
 		// ナレッジが登録/更新された
 		KnowledgesDao knowledgesDao = KnowledgesDao.get();
 		KnowledgesEntity knowledge = knowledgesDao.selectOnKey(notifyQueuesEntity.getId());
+		if (null == knowledge) {
+			LOG.warn("Knowledge record not found. id: " + notifyQueuesEntity.getId());
+			return;
+		}
+
 		if (knowledge.getPublicFlag() == KnowledgeLogic.PUBLIC_FLAG_PUBLIC) {
 			notifyPublicKnowledgeUpdate(notifyQueuesEntity, knowledge);
 		} else if (knowledge.getPublicFlag() == KnowledgeLogic.PUBLIC_FLAG_PROTECT) {


### PR DESCRIPTION
記事の投稿または更新、参考になった、コメント追加からNotifyMailBatが起動するまでの間に記事の削除またはコメントの削除が行われた場合、データの取得ができないためnullに対してメソッド呼び出しをする形になり処理が落ちていたためnullチェックをしてnullであればスキップするようにしました。

データが取得できない場合は以下のようなログが出力されます。

```
INFO  2015-10-17 22:03:25,786 [AbstractBat(26)] NotifyMailBat is start.
INFO  2015-10-17 22:03:26,496 [DBConnenctionLogic(35)] Custom connection setting is exists.
INFO  2015-10-17 22:03:26,618 [NotifyMailBat(71)] Notify process started.
WARN  2015-10-17 22:03:27,764 [NotifyMailBat(349)] Knowledge record not found. id: 147
WARN  2015-10-17 22:03:27,876 [NotifyMailBat(128)] Knowledge record not found. id: 267
WARN  2015-10-17 22:03:27,990 [NotifyMailBat(210)] Comment record not found. id: 126
WARN  2015-10-17 22:03:27,994 [NotifyMailBat(349)] Knowledge record not found. id: 139
INFO  2015-10-17 22:03:27,996 [NotifyMailBat(87)] Notify process finished. count: 4
INFO  2015-10-17 22:03:27,996 [AbstractBat(38)] Finished
```
