### PR TITLE
Fix/issue102 freeze on codehighlight

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "respond": "1.4.2",
     "notifyjs": "0.3.2",
     "marked": "0.3.2",
-    "highlightjs": "8.3.0",
+    "highlightjs": "8.8.0",
     "bootbox": "4.3.0",
     "bootstrap-tagsinput": "0.4.2",
     "bootstrap3-typeahead": "3.1.1",
@@ -17,7 +17,8 @@
     "teambox.free-file-icons": "teambox/Free-file-icons",
     "echojs": "1.6.0",
     "notify.js": "1.2.5",
-    "emoji-parser": "0.1.1"
+    "emoji-parser": "0.1.1",
+    "bluebird": "2.10.2"
   },
   "devDependencies": {}
 }

--- a/src/main/webapp/WEB-INF/views/commons/layout/commonScripts.jsp
+++ b/src/main/webapp/WEB-INF/views/commons/layout/commonScripts.jsp
@@ -11,6 +11,8 @@
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jquery/dist/jquery.min.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/bootstrap/dist/js/bootstrap.min.js"></script>
 
+<script type="text/javascript" src="<%= request.getContextPath() %>/bower/bluebird/js/browser/bluebird.min.js"></script>
+
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/notifyjs/dist/notify.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/notifyjs/dist/notify-combined.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/notifyjs/dist/styles/bootstrap/notify-bootstrap.js"></script>

--- a/src/main/webapp/WEB-INF/views/open/knowledge/view.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/view.jsp
@@ -25,11 +25,14 @@
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/bootstrap-tagsinput/dist/bootstrap-tagsinput.min.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/echojs/dist/echo.min.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/emoji-parser/main.min.js"></script>
-<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-view.js") %>"></script>
 
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jquery-file-upload/js/vendor/jquery.ui.widget.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jquery-file-upload/js/jquery.fileupload.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jquery-file-upload/js/jquery.iframe-transport.js"></script>
+
+<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-common.js") %>"></script>
+<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-view.js") %>"></script>
+
 
 <script>
 var LABEL_LIKE = '<%= jspUtil.label("knowledge.view.like") %>';

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/edit_comment.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/edit_comment.jsp
@@ -33,6 +33,8 @@
 	var _SET_IMAGE_LABEL= '<%= jspUtil.label("knowledge.edit.set.image.path") %>';
 	</script>
 	<script type="text/javascript" src="<%= request.getContextPath() %>/bower/emoji-parser/main.min.js"></script>
+	
+	<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-common.js") %>"></script>
 	<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/comment.js") %>"></script>
 </c:param>
 

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/view_add.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/view_add.jsp
@@ -26,6 +26,7 @@
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jquery-file-upload/js/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/emoji-parser/main.min.js"></script>
 <script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/tagselect.js") %>"></script>
+<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-common.js") %>"></script>
 <script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-edit.js") %>"></script>
 
 <script>

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/view_edit.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/view_edit.jsp
@@ -26,6 +26,8 @@
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jquery-file-upload/js/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/emoji-parser/main.min.js"></script>
 <script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/tagselect.js") %>"></script>
+
+<script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-common.js") %>"></script>
 <script type="text/javascript" src="<%= jspUtil.mustReloadFile("/js/knowledge-edit.js") %>"></script>
 
 <script>

--- a/src/main/webapp/js/comment.js
+++ b/src/main/webapp/js/comment.js
@@ -116,12 +116,15 @@ var preview = function() {
 		html += '</div>';
 		html += '</div>';
 		html += '</div>';
-		$('#preview').html(html);
-		$('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
+		
+		var jqObj = $('#preview');
+		jqObj.html(html);
+		codeHighlight(jqObj)
+		.then(function() {
+			var content = emoji(jqObj.html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
+			jqObj.html(content);
+			return;
 		});
-		var content = emoji($('#preview').html(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
-		$('#preview').html(content);
 	});
 };
 	

--- a/src/main/webapp/js/knowledge-common.js
+++ b/src/main/webapp/js/knowledge-common.js
@@ -1,0 +1,25 @@
+var emoji = window.emojiParser;
+
+var codeHighlight = function(block) {
+	var highlightPromises = [];
+	block.find('pre code').each(function(i, block) {
+		var jqobj = $(this);
+		highlightPromises.push(new Promise(function(resolve, reject) {
+			try {
+				var text = jqobj.text();
+				if (text.indexOf('://') != -1) {
+					console.log('skip on hljs freeze word');
+					console.log(text);
+					return resolve();
+				}
+				var result = hljs.highlightAuto(text);
+				jqobj.html(result.value);
+				return resolve();
+			} catch(err) {
+				console.err(err);
+				return reject(err);
+			}
+		}));
+	});
+	return Promise.all(highlightPromises);
+};

--- a/src/main/webapp/js/knowledge-edit.js
+++ b/src/main/webapp/js/knowledge-edit.js
@@ -4,7 +4,6 @@ var editors = [];
 var selectedEditors = [];
 
 $(document).ready(function() {
-	hljs.initHighlightingOnLoad();
 	marked.setOptions({
 		langPrefix : '',
 		highlight : function(code, lang) {
@@ -366,17 +365,22 @@ var preview = function() {
 		html += '</div>';
 		html += '</div>';
 		html += '</div>';
-		$('#preview').html(html);
-		$('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
-		});
-		var content = emoji($('#preview').html(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
-		$('#preview').html(content);
 		
-		var speed = 500;
-		var target = $('#preview');
-		var position = target.offset().top;
-		$("html, body").animate({scrollTop:position}, speed, "swing");
+		var jqObj = $('#preview');
+		jqObj.html(html);
+		codeHighlight(jqObj)
+		.then(function() {
+			var content = emoji(jqObj.html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
+			jqObj.html(content);
+			
+			var speed = 500;
+			var target = $('#preview');
+			var position = target.offset().top;
+			$("html, body").animate({scrollTop:position}, speed, "swing");
+			
+			return;
+		});
+		
 	});
 };
 

--- a/src/main/webapp/js/knowledge-list.js
+++ b/src/main/webapp/js/knowledge-list.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-	hljs.initHighlightingOnLoad();
+//	hljs.initHighlightingOnLoad();
 	marked.setOptions({
 		langPrefix : '',
 		highlight : function(code, lang) {

--- a/src/main/webapp/js/knowledge-view.js
+++ b/src/main/webapp/js/knowledge-view.js
@@ -1,4 +1,3 @@
-var emoji;
 $(document).ready(function(){
 	marked.setOptions({
 		langPrefix: '',
@@ -7,7 +6,6 @@ $(document).ready(function(){
 			return code;
 		}
 	});
-	emoji = window.emojiParser;
 	
 	codeHighlight($('#content'))
 	.then(function() {console.log('finish codeHighlight.'); return;});
@@ -326,26 +324,4 @@ var addTemplateItem = function(template) {
 	}
 };
 
-var codeHighlight = function(block) {
-	var highlightPromises = [];
-	block.find('pre code').each(function(i, block) {
-		var jqobj = $(this);
-		highlightPromises.push(new Promise(function(resolve, reject) {
-			try {
-				var text = jqobj.text();
-				if (text.indexOf('://') != -1) {
-					console.log('skip on hljs freeze word');
-					console.log(text);
-					return resolve();
-				}
-				var result = hljs.highlightAuto(text);
-				jqobj.html(result.value);
-				return resolve();
-			} catch(err) {
-				console.err(err);
-				return reject(err);
-			}
-		}));
-	});
-	return Promise.all(highlightPromises);
-};
+

--- a/src/main/webapp/js/knowledge-view.js
+++ b/src/main/webapp/js/knowledge-view.js
@@ -1,5 +1,5 @@
+var emoji;
 $(document).ready(function(){
-	hljs.initHighlightingOnLoad();
 	marked.setOptions({
 		langPrefix: '',
 		highlight: function(code, lang) {
@@ -7,15 +7,15 @@ $(document).ready(function(){
 			return code;
 		}
 	});
-	var emoji = window.emojiParser;
-	$('#content').find('pre code').each(function(i, block) {
-		hljs.highlightBlock(block);
-	});
+	emoji = window.emojiParser;
 	
-	console.log($('#content').html());
+	codeHighlight($('#content'))
+	.then(function() {console.log('finish codeHighlight.'); return;});
+	
+	//console.log($('#content').html());
 	var html = emoji($('#content').html(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
 	$('#content').html(html);
-	console.log($('#content').html());
+	//console.log($('#content').html());
 	
 	echo.init();
 	
@@ -35,25 +35,25 @@ $(document).ready(function(){
 	
 	$('.arrow_question').each(function(i, block) {
 		var content = $(this).html().trim();
-		//content = marked(content);
-		$(this).html(content);
-		$(this).find('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
+		var jqObj = $(this);
+		jqObj.html(content);
+		codeHighlight(jqObj)
+		.then(function() {
+			var content = emoji(jqObj.html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
+			jqObj.html(content);
+			return;
 		});
-		var content = emoji($(this).html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
-		console.log(content);
-		$(this).html(content);
 	});
 	$('.arrow_answer').each(function(i, block) {
 		var content = $(this).html().trim();
-		//content = marked(content);
-		$(this).html(content);
-		$(this).find('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
+		var jqObj = $(this);
+		jqObj.html(content);
+		codeHighlight(jqObj)
+		.then(function() {
+			var content = emoji(jqObj.html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
+			jqObj.html(content);
+			return;
 		});
-		var content = emoji($(this).html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
-		console.log(content);
-		$(this).html(content);
 	});
 	
 	$('#emojiPeopleModal').on('loaded.bs.modal', function (event) {
@@ -204,13 +204,14 @@ var preview = function() {
 		html += '</div><!-- /.arrow_question -->';
 		html += '</div><!-- /.question_Box -->';
 		
-		$('#preview').html(html);
-		$('#preview').find('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
+		var jqObj = $('#preview');
+		jqObj.html(html);
+		codeHighlight(jqObj)
+		.then(function() {
+			var content = emoji(jqObj.html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
+			jqObj.html(content);
+			return;
 		});
-		var emoji = window.emojiParser;
-		var content = emoji($('#preview').html(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
-		$('#preview').html(content);
 	});
 };
 
@@ -234,13 +235,14 @@ var previewans = function() {
 		html += '</div>';
 		html += '</div>';
 		
-		$('#preview').html(html);
-		$('#preview').find('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
+		var jqObj = $('#preview');
+		jqObj.html(html);
+		codeHighlight(jqObj)
+		.then(function() {
+			var content = emoji(jqObj.html().trim(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
+			jqObj.html(content);
+			return;
 		});
-		var emoji = window.emojiParser;
-		var content = emoji($('#preview').html(), _CONTEXT + '/bower/emoji-parser/emoji', {classes: 'emoji-img'});
-		$('#preview').html(content);
 	});
 };
 
@@ -324,4 +326,26 @@ var addTemplateItem = function(template) {
 	}
 };
 
-
+var codeHighlight = function(block) {
+	var highlightPromises = [];
+	block.find('pre code').each(function(i, block) {
+		var jqobj = $(this);
+		highlightPromises.push(new Promise(function(resolve, reject) {
+			try {
+				var text = jqobj.text();
+				if (text.indexOf('://') != -1) {
+					console.log('skip on hljs freeze word');
+					console.log(text);
+					return resolve();
+				}
+				var result = hljs.highlightAuto(text);
+				jqobj.html(result.value);
+				return resolve();
+			} catch(err) {
+				console.err(err);
+				return reject(err);
+			}
+		}));
+	});
+	return Promise.all(highlightPromises);
+};


### PR DESCRIPTION
- コードハイライト処理の中でフリーズしたようになるので対応しました ( #102)
    - コードハイライトをPromise化して非同期にする
    - ハイライトするテキストの中にURLスキーム形式があると、Chromeがそれにアクセスしようとしてフリーズするようなのでスキップする
        - firefoxだと発生しないかも？
        - choromeが主流になっていると思われるので、Chrome用のロジックを全てのブラウザに反映
    - http://xxxx といった文字列があると、ハイライトしなくなることは課題があるが、フリーズするよりはマシと思われるので、いったん対策を施します

