### PR TITLE
v0.6.1の作成

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.support-project</groupId>
 	<artifactId>knowledge</artifactId>
 	<packaging>war</packaging>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<name>webapp for knowledge</name>
 	<url>https://support-project.org/</url>
 
@@ -19,6 +19,12 @@
 			<version>0.6.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.support-project</groupId>
+			<artifactId>markedj</artifactId>
+			<version>1.0.4</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
@@ -115,12 +121,6 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<version>4.3.1</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>io.github.gitbucket</groupId>
-			<artifactId>markedj</artifactId>
-			<version>1.0.4-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -53,7 +53,7 @@ message.allready.updated=Allready updated.
 message.allready.started=Allready started.
 
 # Common Label
-label.version=0.6.0
+label.version=0.6.1
 label.login=Sign in
 label.previous = Previous
 label.next=Next

--- a/src/main/resources/appresource_ja.properties
+++ b/src/main/resources/appresource_ja.properties
@@ -53,7 +53,7 @@ message.allready.updated=すでに更新されています
 message.allready.started=すでに開始済です
 
 # Common Label
-label.version=0.6.0
+label.version=0.6.1
 label.login=サインイン
 label.previous = 前へ
 label.next = 次へ


### PR DESCRIPTION
#### v0.6.0のリリースに対する修正

- デプロイ時に、マークダウンパーサーの変更したライブラリを読み込まなかったので、pom.xmlを修正
- リリースした後に気づいたので、v0.6.1としてリリースする

