### PR TITLE
#137 URLの内容取得でエラーが発生した場合のハンドリング修正

### DIFF
--- a/src/main/java/org/support/project/knowledge/bat/FileParseBat.java
+++ b/src/main/java/org/support/project/knowledge/bat/FileParseBat.java
@@ -92,7 +92,16 @@ public class FileParseBat extends AbstractBat {
 				// タグを取得
 				List<TagsEntity> tagsEntities = TagsDao.get().selectOnKnowledgeId(knowledgesEntity.getKnowledgeId());
 				// Webアクセス
-				String content = logic.crawle(proxyConfigs, itemValue.getItemValue());
+				String content = null;
+				try {
+					content = logic.crawle(proxyConfigs, itemValue.getItemValue());
+				} catch (Exception e) {
+					LOG.error("crawl error:" + itemValue.getItemValue(), e);
+					// ステータス更新(エラー)
+					itemValue.setItemStatus(KnowledgeItemValuesEntity.STATUS_WEBACCESS_ERROR);
+					itemValuesDao.update(itemValue);
+					continue;
+				}
 				if (StringUtils.isNotEmpty(content)) {
 					LOG.info("[SUCCESS] " + itemValue.getItemValue());
 					// 全文検索エンジンにのみ、検索できるように情報登録

--- a/src/main/java/org/support/project/knowledge/entity/KnowledgeItemValuesEntity.java
+++ b/src/main/java/org/support/project/knowledge/entity/KnowledgeItemValuesEntity.java
@@ -18,6 +18,8 @@ public class KnowledgeItemValuesEntity extends GenKnowledgeItemValuesEntity {
 	public static final Integer STATUS_SAVED = 0;
 	/** ステータス: Webの値取得済み */
 	public static final Integer STATUS_WEBACCESSED = 1;
+	/** ステータス: Webの値取得済み */
+	public static final Integer STATUS_WEBACCESS_ERROR = -1;
 
 	/**
 	 * インスタンス取得


### PR DESCRIPTION
bookmarkに指定されたURLに書かれた内容を取得する際にエラーが発生した場合、次のbookmarkのコンテンツを処理するように変更した