### PR TITLE
#105 キーワード検索で検索クエリを指定できるように

### DIFF
--- a/src/main/java/org/support/project/knowledge/logic/KeywordLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KeywordLogic.java
@@ -1,0 +1,54 @@
+package org.support.project.knowledge.logic;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.support.project.di.Container;
+import org.support.project.di.DI;
+import org.support.project.di.Instance;
+
+@DI(instance=Instance.Singleton)
+public class KeywordLogic {
+	public static final Map<String, String> regexList = new HashMap<String, String>();
+
+	static {
+		regexList.put("groups", "(?:groups:(?<groups>[^ ]+))");
+		regexList.put("tags", "(?:tags:(?<tags>[^ ]+))");
+	}
+
+	public static KeywordLogic get() {
+		return Container.getComp(KeywordLogic.class);
+	}
+
+	/**
+	 * 文字列を指定の検索クエリでパースして検索クエリの内容を返す
+	 * 
+	 * @param key
+	 * @param text
+	 * @return String
+	 */
+	public String parseQuery(String key, String text) {
+		Pattern pattern = Pattern.compile(regexList.get(key));
+		Matcher matcher = pattern.matcher(text);
+
+		if (!matcher.find()) {
+			return null;
+		}
+		return  matcher.group(key);
+	}
+
+	/**
+	 * 文字列をパースしてキーワードを返す
+	 * 
+	 * @param text
+	 * @return String
+	 */
+	public String parseKeyword(String text) {
+		text = text.replaceAll(KeywordLogic.regexList.get("groups"), "");
+		text = text.replaceAll(KeywordLogic.regexList.get("tags"), "");
+		text = text.trim();
+		return text;
+	}
+}

--- a/src/main/java/org/support/project/knowledge/logic/KeywordLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KeywordLogic.java
@@ -14,8 +14,8 @@ public class KeywordLogic {
 	public static final Map<String, String> regexList = new HashMap<String, String>();
 
 	static {
-		regexList.put("groups", "(?:groups:(?<groups>[^ ]+))");
-		regexList.put("tags", "(?:tags:(?<tags>[^ ]+))");
+		regexList.put("groups", "(?:groups: *\\((?<groups>[^)]+)\\))");
+		regexList.put("tags", "(?:tags: *\\((?<tags>[^)]+)\\))");
 	}
 
 	public static KeywordLogic get() {
@@ -36,7 +36,7 @@ public class KeywordLogic {
 		if (!matcher.find()) {
 			return null;
 		}
-		return  matcher.group(key);
+		return  matcher.group(key).replaceAll(", *", ",");
 	}
 
 	/**

--- a/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
+++ b/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
@@ -223,8 +223,8 @@
 			<form class="nav navbar-nav navbar-form navbar-right" role="search"
 				action="<%= request.getContextPath() %><%= top %>">
 				<div class="input-group">
-					<input type="text" class="form-control" placeholder="<%= jspUtil.label("knowledge.navbar.search.placeholder") %>"
-						name="keyword" id="keyword" value="<%= jspUtil.out("keyword") %>" />
+					<input type="text" class="form-control" style="width: 350px;" placeholder="<%= jspUtil.label("knowledge.navbar.search.placeholder") %>"
+						name="keyword" id="keyword" value="<%= jspUtil.out("searchKeyword") %>" />
 					<div class="input-group-btn">
 						<button class="btn btn-default" type="submit">
 							<i class="glyphicon glyphicon-search"></i>

--- a/src/main/webapp/WEB-INF/views/open/knowledge/search.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/search.jsp
@@ -52,7 +52,7 @@ _GROUPS.push('<%= jspUtil.out("groupitem.groupName") %>');
 			<%= jspUtil.label("knowledge.search.keyword") %>
 			</label>
 			<input type="text" class="form-control" placeholder="<%= jspUtil.label("knowledge.search.placeholder") %>"
-				name="keyword" id="searchkeyword" value="<%=jspUtil.out("keyword")%>" />
+				name="keyword" id="searchkeyword" value="<%=jspUtil.out("searchKeyword")%>" />
 		</div>
 
 		<div class="form-group">


### PR DESCRIPTION
* 実装内容
  * キーワード検索にgroups:グループ名があった場合にグループで絞った結果を出力するように
  * キーワード検索にtags:タグ名があった場合にタグで絞った結果を出力するように
  * groups:またはtags:を指定している状態で一覧から検索画面に遷移した場合にキーワードを分解してそれぞれのフォームに値を入れるように