### PR TITLE
#134 Knowledge一覧にグループ一覧を追加(投稿数順)

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
@@ -27,6 +27,7 @@ import org.support.project.knowledge.entity.TagsEntity;
 import org.support.project.knowledge.entity.TemplateItemsEntity;
 import org.support.project.knowledge.entity.TemplateMastersEntity;
 import org.support.project.knowledge.logic.DiffLogic;
+import org.support.project.knowledge.logic.GroupLogic;
 import org.support.project.knowledge.logic.KeywordLogic;
 import org.support.project.knowledge.logic.KnowledgeLogic;
 import org.support.project.knowledge.logic.MarkdownLogic;
@@ -294,19 +295,27 @@ public class KnowledgeControl extends KnowledgeControlBase {
 			previous = 0;
 		}
 		
-		// タグの情報を取得
-		if (super.getLoginedUser() != null && super.getLoginedUser().isAdmin()) {
+		// タグとグループの情報を取得
+		if (loginedUser != null && loginedUser.isAdmin()) {
 			// 管理者であれば、ナレッジの件数は、参照権限を考慮していない
 	 		List<TagsEntity> tags = tagsDao.selectTagsWithCount(0, PAGE_LIMIT);
 			setAttribute("tags", tags);
+
+			List<GroupsEntity> groups = groupsDao.selectGroupsWithCount(0, PAGE_LIMIT);
+			setAttribute("groups", groups);
 		} else {
 			TagLogic tagLogic = TagLogic.get();
 			List<TagsEntity> tags = tagLogic.selectTagsWithCount(loginedUser, 0, PAGE_LIMIT);
 			setAttribute("tags", tags);
-		}
-		LOG.trace("タグ取得完了");
 
-		
+			if (loginedUser != null) {
+				GroupLogic groupLogic = GroupLogic.get();
+				List<GroupsEntity> groups = groupLogic.selectMyGroup(loginedUser, 0, PAGE_LIMIT);
+				setAttribute("groups", groups);
+			}
+		}
+		LOG.trace("タグ、グループ取得完了");
+
 		// History表示
 		// TODO 履歴表示を毎回取得するのはイマイチ。いったんセッションに保存しておくのが良いかも
 		Cookie[] cookies = getRequest().getCookies();

--- a/src/main/java/org/support/project/knowledge/logic/GroupLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/GroupLogic.java
@@ -114,7 +114,7 @@ public class GroupLogic {
 		GroupsDao groupsDao = GroupsDao.get();
 		if (loginedUser.isAdmin()) {
 			if (StringUtils.isEmpty(keyword)) {
-				list = groupsDao.selectAll(offset, limit);
+				list = groupsDao.selectGroupsWithCount(offset, limit);
 			} else {
 				list = groupsDao.selectOnKeyword(keyword, loginedUser, offset, limit);
 			}
@@ -170,7 +170,7 @@ public class GroupLogic {
 
 		return list;
 	}
-	
+
 	/**
 	 * 自分が指定のグループの所属状態がどうなっているかセットする
 	 * @param groupsEntity

--- a/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
@@ -193,18 +193,37 @@
 			
 			
 			<h5>- <i class="fa fa-group"></i>&nbsp;<%= jspUtil.label("knowledge.navbar.config.group") %> - </h5>
+			<c:choose>
+			<c:when test="${groups != null}">
 			<div class="list-group">
-				<a class="list-group-item " href="<%= request.getContextPath() %>/protect.group/mygroups" style="cursor: pointer;">
-					<i class="fa fa-users"></i>&nbsp;<%= jspUtil.label("knowledge.navbar.config.group.list") %>
+				<c:forEach var="group_item" items="${groups}">
+				<a class="list-group-item"
+					href="<%= request.getContextPath() %>/open.knowledge/list?group=<%= jspUtil.out("group_item.groupId") %>" >
+					<span class="badge"><%= jspUtil.out("group_item.groupKnowledgeCount") %></span>
+					<i class="fa fa-group"></i>&nbsp;<%= jspUtil.out("group_item.groupName") %>
 				</a>
+				</c:forEach>
 			</div>
+			<div style="width: 100%;text-align: right;">
+				<a href="<%= request.getContextPath() %>/protect.group/mygroups">
+					<i class="fa fa-group"></i>&nbsp;<%= jspUtil.label("knowledge.navbar.config.group.list") %>
+				</a>&nbsp;&nbsp;&nbsp;
+			</div>
+	        </c:when>
+	        <c:otherwise>
+			<div class="list-group">
+                <a class="list-group-item " href="<%= request.getContextPath() %>/protect.group/mygroups" style="cursor: pointer;">
+	                <i class="fa fa-users"></i>&nbsp;<%= jspUtil.label("knowledge.navbar.config.group.list") %>
+	            </a>
+	        </div>
+			</c:otherwise>
+			</c:choose>
 			<br/>
 			
 			<h5>- <i class="fa fa-tags"></i>&nbsp;<%= jspUtil.label("knowledge.list.popular.tags") %> - </h5>
-			
 			<div class="list-group">
 			<c:forEach var="tag_item" items="${tags}">
-				<a class="list-group-item " 
+				<a class="list-group-item"
 					href="<%= request.getContextPath() %>/open.knowledge/list?tag=<%= jspUtil.out("tag_item.tagId") %>" >
 					<span class="badge"><%= jspUtil.out("tag_item.knowledgeCount") %></span>
 					<i class="fa fa-tag"></i>&nbsp;<%= jspUtil.out("tag_item.tagName") %>


### PR DESCRIPTION
* 実装内容
  * 投稿一覧ページに投稿順のグループ一覧と投稿数のリストを表示するように
    * 見た目制御
      * 未ログインユーザの場合は現状と同じくリンクのみを設置
      * ログインユーザは所属グループの上位10件をリスト表示
      * 管理ユーザは全グループの上位10件をリスト表示

よろしくお願いします。

@see support-project/web#8