### PR TITLE
#151 外部リンクに `target="_blank"` の対応

### DIFF
--- a/src/test/java/org/support/project/knowledge/logic/MarkdownLogicTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/MarkdownLogicTest.java
@@ -171,7 +171,7 @@ public class MarkdownLogicTest extends TestCommon {
 		try {
 			org.junit.Assert.assertArrayEquals(read(html), read(result));
 		} catch (AssertionError e) {
-			LOG.info("test5");
+			LOG.info("test6");
 			LOG.info("[Markdown] : " + markdown);
 			LOG.info("[Html]     : " + html);
 			LOG.info("[Parsed]   : " + result);
@@ -185,7 +185,7 @@ public class MarkdownLogicTest extends TestCommon {
 		try {
 			org.junit.Assert.assertArrayEquals(read(html), read(result));
 		} catch (AssertionError e) {
-			LOG.info("test5");
+			LOG.info("test6-2");
 			LOG.info("[Markdown] : " + markdown);
 			LOG.info("[Html]     : " + html);
 			LOG.info("[Parsed]   : " + result);
@@ -228,7 +228,24 @@ public class MarkdownLogicTest extends TestCommon {
 		}
 	}
 	
-	
+
+	@Test
+	@Order(order= 8)
+	public void testMarkdJLink() throws ParseException, UnsupportedEncodingException, IOException, TransformerFactoryConfigurationError, TransformerException {
+		String markdown = FileUtil.read(getClass().getResourceAsStream("markdown/markdj-link.md"));
+		String html = FileUtil.read(getClass().getResourceAsStream("markdown/result-markdj-link.txt"));
+		String result = MarkdownLogic.get().markdownToHtml(markdown, MarkdownLogic.ENGINE_MARKEDJ).getHtml();
+		try {
+			org.junit.Assert.assertArrayEquals(read(html), read(result));
+		} catch (AssertionError e) {
+			LOG.info("testMarkdJ1");
+			LOG.info("[Markdown] : " + markdown);
+			LOG.info("[Html]     : " + html);
+			LOG.info("[Parsed]   : " + result);
+			LOG.info("[Indent]   : " + SanitizingLogic.get().indent(result));
+			throw e;
+		}
+	}
 	
 	
 }

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/markdj-link.md
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/markdj-link.md
@@ -1,0 +1,1 @@
+https://support-project.org/knowledge/index

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/result-4.txt
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/result-4.txt
@@ -3,7 +3,7 @@
 <ul><li>Javascriptで簡単にパースしていたけど、Java側で実行した方が制御しやすいね</li><li>危険な</li></ul><h3>Script</h3>
 <p>これ通る&#xff1f;<br /></p><p>通らない</p>
 <ul><li>PegDownProcessorだけだと、そのまま出力する&#xff08;XSSでやばそう&#xff09;</li><li>サニタイジングする</li></ul>
-<pre><code class="ruby:qiita.rb">puts &#39;The best way to log and share programmers knowledge.&#39;
+<pre><code>puts &#39;The best way to log and share programmers knowledge.&#39;
 </code></pre>
 <pre><code class="html">&lt;button&gt;hogehoge&lt;/button&gt;
 </code></pre>

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/result-5.txt
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/result-5.txt
@@ -3,7 +3,7 @@
 <ul><li>Javascriptで簡単にパースしていたけど、Java側で実行した方が制御しやすいね</li><li>危険な</li></ul><h3>Script</h3>
 <p>これ通る&#xff1f;<br /></p><p>通らない</p>
 <ul><li>PegDownProcessorだけだと、そのまま出力する&#xff08;XSSでやばそう&#xff09;</li><li>サニタイジングする</li></ul>
-<pre><code class="ruby:qiita.rb">puts &#39;The best way to log and share programmers knowledge.&#39;
+<pre><code>puts &#39;The best way to log and share programmers knowledge.&#39;
 </code></pre>
 <pre><code class="html">&lt;button&gt;hogehoge&lt;/button&gt;
 </code></pre>

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/result-6-2.txt
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/result-6-2.txt
@@ -13,7 +13,7 @@
 これ通る&#xff1f;</p>
 <p></p><p>通らない</p>
 <ul><li>PegDownProcessorだけだと、そのまま出力する&#xff08;XSSでやばそう&#xff09;</li><li>サニタイジングする</li></ul>
-<pre><code class="lang-ruby:qiita.rb">puts &#39;The best way to log and share programmers knowledge.&#39;
+<pre><code>puts &#39;The best way to log and share programmers knowledge.&#39;
 </code></pre>
 <pre><code class="lang-html">&lt;button&gt;hogehoge&lt;/button&gt;
 </code></pre>

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/result-6.txt
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/result-6.txt
@@ -9,7 +9,7 @@
 これ通る&#xff1f;</p>
 <p></p><p>通らない</p>
 <ul><li>PegDownProcessorだけだと、そのまま出力する&#xff08;XSSでやばそう&#xff09;</li><li>サニタイジングする</li></ul>
-<pre><code class="lang-ruby:qiita.rb">puts &#39;The best way to log and share programmers knowledge.&#39;
+<pre><code>puts &#39;The best way to log and share programmers knowledge.&#39;
 </code></pre>
 <pre><code class="lang-html">&lt;button&gt;hogehoge&lt;/button&gt;
 </code></pre>

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/result-markdj-1.txt
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/result-markdj-1.txt
@@ -8,7 +8,7 @@
 <p>通らない</p>
 
 <ul><li>PegDownProcessorだけだと、そのまま出力する&#xff08;XSSでやばそう&#xff09;</li><li>サニタイジングする</li></ul>
-<pre><code class="lang-ruby:qiita.rb">puts &#39;The best way to log and share programmers knowledge.&#39;
+<pre><code>puts &#39;The best way to log and share programmers knowledge.&#39;
 </code></pre>
 <pre><code class="lang-html">&lt;button&gt;hogehoge&lt;/button&gt;
 </code></pre>

--- a/src/test/resources/org/support/project/knowledge/logic/markdown/result-markdj-link.txt
+++ b/src/test/resources/org/support/project/knowledge/logic/markdown/result-markdj-link.txt
@@ -1,0 +1,1 @@
+<p><a href="https://support-project.org/knowledge/index" target="_blank" rel="nofollow">https://support-project.org/knowledge/index</a></p>


### PR DESCRIPTION
- Markdownのパース結果の外部リンクでアンカーを生成する際に、 target="_blank" を追加
    - Markdownのパーサーを修正
    - サニタイジング処理で target を消すのでそこも修正
    - knowledgeでは、テストケースの期待値を修正するのみ