### PR TITLE
Fix/issue162 save error

### DIFF
--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -1229,6 +1229,11 @@ public class KnowledgeLogic {
 		if (loginedUser.isAdmin()) {
 			return true;
 		} else {
+			if (entity != null) {
+				if (entity.getInsertUser().intValue() == loginedUser.getUserId().intValue()) {
+					return true;
+				}
+			}
 			for (LabelValue labelValue : editors) {
 				Integer id = TargetLogic.get().getGroupId(labelValue.getValue());
 				if (id != Integer.MIN_VALUE) {

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -199,7 +199,6 @@ public class KnowledgeLogic {
 		editUsersDao.deleteOnKnowledgeId(entity.getKnowledgeId());
 		editGroupsDao.deleteOnKnowledgeId(entity.getKnowledgeId());
 		
-		
 		// アクセス権を登録
 		saveAccessUser(entity, loginedUser, targets);
 		// 編集権を登録
@@ -295,12 +294,6 @@ public class KnowledgeLogic {
 		KnowledgeEditUsersDao editUsersDao = KnowledgeEditUsersDao.get();
 		KnowledgeEditGroupsDao editGroupsDao = KnowledgeEditGroupsDao.get();
 		
-		// ナレッジにアクセス可能なユーザに、自分自身をセット
-		KnowledgeEditUsersEntity editUsersEntity = new KnowledgeEditUsersEntity();
-		editUsersEntity.setKnowledgeId(entity.getKnowledgeId());
-		editUsersEntity.setUserId(loginedUser.getLoginUser().getUserId());
-		editUsersDao.save(editUsersEntity);
-		
 		// 編集権限を設定
 		if (editors != null && !editors.isEmpty()) {
 			for (int i = 0; i < editors.size(); i++) {
@@ -318,7 +311,7 @@ public class KnowledgeLogic {
 							&& loginedUser.getUserId().intValue() != id.intValue()
 							&& ALL_USER != id.intValue()
 					) {
-						editUsersEntity = new KnowledgeEditUsersEntity();
+						KnowledgeEditUsersEntity editUsersEntity = new KnowledgeEditUsersEntity();
 						editUsersEntity.setKnowledgeId(entity.getKnowledgeId());
 						editUsersEntity.setUserId(id);
 						editUsersDao.save(editUsersEntity);


### PR DESCRIPTION
#162 の対応

ナレッジを新規登録時後に、再度保存をしようとするとエラーになっていた。
登録者であっても、「共同編集者」に自分が登録されているかをチェックしていたのが原因。

ナレッジの登録者は、常に編集できるようにして良いので、編集権限チェックを修正した。
また、登録者は常に編集できるようにしたので、登録時の「共同編集者」に自分自身をセットする事をやめるようにした。