### PR TITLE
#119 保存後、タグの選択状態が変更されないように修正

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
@@ -133,6 +133,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
 	
 	/**
 	 * 登録する
+	 * APIによる保存とし、画面遷移は行わない
 	 * @return
 	 * @throws Exception 
 	 * @throws ParseException 
@@ -157,19 +158,11 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		setAttribute("tagitems", tagitems);
 		
 		List<Long> fileNos = new ArrayList<Long>();
-		Object obj = getParam("files", Object.class);
-		if (obj != null) {
-			if (obj instanceof String) {
-				String string = (String) obj;
+		String[] filesArray = getParam("files", String[].class);
+		if (filesArray != null) {
+			for (String string : filesArray) {
 				if (StringUtils.isLong(string)) {
 					fileNos.add(new Long(string));
-				}
-			} else if (obj instanceof List) {
-				List<String> strings = (List<String>) obj;
-				for (String string : strings) {
-					if (StringUtils.isLong(string)) {
-						fileNos.add(new Long(string));
-					}
 				}
 			}
 		}
@@ -191,20 +184,8 @@ public class KnowledgeControl extends KnowledgeControlBase {
 
 		List<ValidateError> errors = entity.validate();
 		if (!errors.isEmpty()) {
-			setResult(null, errors);
-			// バリデーションエラーが発生した場合、設定されていた添付ファイルの情報は再取得
-			List<UploadFile> files = fileLogic.selectOnFileNos(fileNos, getRequest().getContextPath());
-			Iterator<UploadFile> iterator = files.iterator();
-			while (iterator.hasNext()) {
-				UploadFile uploadFile = (UploadFile) iterator.next();
-				if (uploadFile.getKnowlegeId() != null) {
-					// 新規登録なのに、添付ファイルが既にナレッジに紐づいている（おかしい）
-					iterator.remove();
-				}
-			}
-			setAttribute("files", files);
-
-			return forward("view_add.jsp");
+			//入力エラー
+			return sendValidateError(errors);
 		}
 		LOG.trace("save");
 		String tags = super.getParam("tagNames");
@@ -217,11 +198,13 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		setAttribute("files", files);
 		
 		addMsgSuccess("message.success.insert");
-		return forward("view_edit.jsp");
+//		return forward("view_edit.jsp");
+		return sendMsg(MessageStatus.Success, HttpStatus.SC_200_OK, String.valueOf(entity.getKnowledgeId()), "message.success.insert");
 	}
 	
 	/**
 	 * 更新する
+	 * APIによる保存とし、画面遷移は行わない
 	 * @return
 	 * @throws Exception 
 	 */
@@ -244,19 +227,11 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		setAttribute("tagitems", tagitems);
 		
 		List<Long> fileNos = new ArrayList<Long>();
-		Object obj = getParam("files", Object.class);
-		if (obj != null) {
-			if (obj instanceof String) {
-				String string = (String) obj;
+		String[] filesArray = getParam("files", String[].class);
+		if (filesArray != null) {
+			for (String string : filesArray) {
 				if (StringUtils.isLong(string)) {
 					fileNos.add(new Long(string));
-				}
-			} else if (obj instanceof List) {
-				List<String> strings = (List<String>) obj;
-				for (String string : strings) {
-					if (StringUtils.isLong(string)) {
-						fileNos.add(new Long(string));
-					}
 				}
 			}
 		}
@@ -279,22 +254,8 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		KnowledgesDao dao = Container.getComp(KnowledgesDao.class);
 		List<ValidateError> errors = entity.validate();
 		if (!errors.isEmpty()) {
-			setResult(null, errors);
-			
-			// バリデーションエラーが発生した場合、設定されていた添付ファイルの情報は再取得
-			List<UploadFile> files = fileLogic.selectOnFileNos(fileNos, getRequest().getContextPath());
-			Iterator<UploadFile> iterator = files.iterator();
-			while (iterator.hasNext()) {
-				UploadFile uploadFile = (UploadFile) iterator.next();
-				if (uploadFile.getKnowlegeId() != null 
-						&& uploadFile.getKnowlegeId().longValue() != entity.getKnowledgeId().longValue()) {
-					// ナレッジIDが空でなく、かつ、更新中のナレッジ以外に紐づいている添付ファイルはおかしいので削除
-					iterator.remove();
-				}
-			}
-			setAttribute("files", files);
-			
-			return forward("view_edit.jsp");
+			//入力エラー
+			return sendValidateError(errors);
 		}
 		
 		KnowledgesEntity check = dao.selectOnKey(entity.getKnowledgeId());
@@ -305,8 +266,11 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		if (!knowledgeLogic.isEditor(super.getLoginedUser(), check, editors)) {
 			setAttribute("edit", false);
 			addMsgWarn("knowledge.edit.noaccess");
-			//return forward("/open/knowledge/view.jsp");
-			return devolution(HttpMethod.get, "open.Knowledge/view", String.valueOf(entity.getKnowledgeId()));
+//			return devolution(HttpMethod.get, "open.Knowledge/view", String.valueOf(entity.getKnowledgeId()));
+			
+			errors = new ArrayList<>();
+			errors.add(new ValidateError("knowledge.edit.noaccess"));
+			return sendValidateError(errors);
 		}
 		
 		LOG.trace("save");
@@ -320,7 +284,8 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		List<UploadFile> files = fileLogic.selectOnKnowledgeIdWithoutCommentFiles(entity.getKnowledgeId(), getRequest().getContextPath());
 		setAttribute("files", files);
 		
-		return forward("view_edit.jsp");
+		// return forward("view_edit.jsp");
+		return sendMsg(MessageStatus.Success, HttpStatus.SC_200_OK, String.valueOf(entity.getKnowledgeId()), "message.success.update");
 	}
 	
 	/**

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/view_add.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/view_add.jsp
@@ -37,6 +37,8 @@ var _REMOVE_FILE = '<%= jspUtil.label("knowledge.edit.label.delete.upload") %>';
 var _FAIL_REMOVE_FILE = '<%= jspUtil.label("knowledge.edit.label.fail.delete.upload") %>';
 var _CONFIRM = '<%= jspUtil.label("knowledge.edit.label.confirm.delete") %>';
 var _SET_IMAGE_LABEL= '<%= jspUtil.label("knowledge.edit.set.image.path") %>';
+var _LABEL_UPDATE = '<%= jspUtil.label("label.update") %>';
+var _UPDATE_TITLE = '<%= jspUtil.label("knowledge.edit.title") %>';
 
 <c:forEach var="group" items="${groups}" varStatus="status">
 selectedGroups.push({label: '<%= jspUtil.out("group.label") %>', value: '<%= jspUtil.out("group.value") %>'});
@@ -57,9 +59,9 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 
 
 <c:param name="PARAM_CONTENT">
-<h4 class="title"><%= jspUtil.label("knowledge.add.title") %></h4>
+<h4 class="title" id="title_msg"><%= jspUtil.label("knowledge.add.title") %></h4>
 
-<form action="<%= request.getContextPath()%>/protect.knowledge/add" method="post" role="form" enctype="multipart/form-data">
+<form action="<%= request.getContextPath()%>/protect.knowledge/add" method="post" role="form" enctype="multipart/form-data" id="knowledgeForm">
 	
 	<!-- template -->
 	<div class="form-group">
@@ -204,6 +206,8 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 		</p>
 	</div>
 	
+	<input type="hidden" name="knowledgeId" value="" id="knowledgeId" />
+
 	<input type="hidden" name="offset" value="<%= jspUtil.out("offset") %>" />
 	<input type="hidden" name="keyword" value="<%= jspUtil.out("keyword") %>" />
 	<input type="hidden" name="tag" value="<%= jspUtil.out("tag") %>" />
@@ -211,8 +215,17 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 	
 	<!-- buttons -->
 	<hr/>
-	<button type="submit" class="btn btn-primary"><i class="fa fa-save"></i>&nbsp;<%= jspUtil.label("label.save") %></button>
+	<button type="submit" class="btn btn-primary" id="savebutton"><i class="fa fa-save"></i>&nbsp;<%= jspUtil.label("label.save") %></button>
 	<button type="button" class="btn btn-info" onclick="preview();"><i class="fa fa-play-circle"></i>&nbsp;<%= jspUtil.label("label.preview") %></button>
+	
+	<button type="button" class="btn btn-danger hide" onclick="deleteKnowledge();" id="deleteButton">
+		<i class="fa fa-remove"></i>&nbsp;<%= jspUtil.label("label.delete") %>
+	</button>
+	<a href="<%= request.getContextPath() %>/open.knowledge/view/<%= jspUtil.out("knowledgeId") %><%= jspUtil.out("params") %>"
+		class="btn btn-warning hide" role="button" id="cancelButton">
+		<i class="fa fa-undo"></i>&nbsp;<%= jspUtil.label("label.cancel") %>
+	</a>
+	
 	<a href="<%= request.getContextPath() %>/open.knowledge/list/<%= jspUtil.out("offset") %><%= jspUtil.out("params") %>"
 		class="btn btn-success" role="button"><i class="fa fa-list-ul"></i>&nbsp;<%= jspUtil.label("label.backlist") %>
 	</a>
@@ -332,6 +345,10 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 <jsp:include page="markdown.jsp"></jsp:include>
 <jsp:include page="../../open/tag/dialog.jsp"></jsp:include>
 
+
+<form action="<%= request.getContextPath()%>/protect.knowledge/delete" method="post" role="form" id="knowledgeDeleteForm">
+	<input type="hidden" name="knowledgeId" value="<%= jspUtil.out("knowledgeId") %>" id="knowledgeIdForDelete" />
+</form>
 
 </c:param>
 

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/view_edit.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/view_edit.jsp
@@ -38,6 +38,8 @@ var _REMOVE_FILE = '<%= jspUtil.label("knowledge.edit.label.delete.upload") %>';
 var _FAIL_REMOVE_FILE = '<%= jspUtil.label("knowledge.edit.label.fail.delete.upload") %>';
 var _CONFIRM = '<%= jspUtil.label("knowledge.edit.label.confirm.delete") %>';
 var _SET_IMAGE_LABEL= '<%= jspUtil.label("knowledge.edit.set.image.path") %>';
+var _LABEL_UPDATE = '<%= jspUtil.label("label.update") %>';
+var _UPDATE_TITLE = '<%= jspUtil.label("knowledge.edit.title") %>';
 
 <c:forEach var="group" items="${groups}" varStatus="status">
 selectedGroups.push({label: '<%= jspUtil.out("group.label") %>', value: '<%= jspUtil.out("group.value") %>'});
@@ -59,7 +61,7 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 
 
 <c:param name="PARAM_CONTENT">
-<h4 class="title"><%= jspUtil.label("knowledge.edit.title") %></h4>
+<h4 class="title" id="title_msg"><%= jspUtil.label("knowledge.edit.title") %></h4>
 <form action="<%= request.getContextPath()%>/protect.knowledge/update" method="post" role="form" id="knowledgeForm" enctype="multipart/form-data">
 	<!-- info -->
 	<div class="form-group">
@@ -224,14 +226,17 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 	<!-- buttons -->
 	<hr/>
 	
-	<button type="submit" class="btn btn-primary"><i class="fa fa-save"></i>&nbsp;<%= jspUtil.label("label.save") %></button>
+	<button type="submit" class="btn btn-primary" id="savebutton"><i class="fa fa-save"></i>&nbsp;<%= jspUtil.label("label.save") %></button>
 	<button type="button" class="btn btn-info" onclick="preview();"><i class="fa fa-play-circle"></i>&nbsp;<%= jspUtil.label("label.preview") %></button>
 	
-	<button type="button" class="btn btn-danger" onclick="deleteKnowledge();"><i class="fa fa-remove"></i>&nbsp;<%= jspUtil.label("label.delete") %></button>
-	
+	<button type="button" class="btn btn-danger" onclick="deleteKnowledge();" id="deleteButton">
+		<i class="fa fa-remove"></i>&nbsp;<%= jspUtil.label("label.delete") %>
+	</button>
 	<a href="<%= request.getContextPath() %>/open.knowledge/view/<%= jspUtil.out("knowledgeId") %><%= jspUtil.out("params") %>"
-		class="btn btn-warning" role="button"><i class="fa fa-undo"></i>&nbsp;<%= jspUtil.label("label.cancel") %>
+		class="btn btn-warning" role="button" id="cancelButton">
+		<i class="fa fa-undo"></i>&nbsp;<%= jspUtil.label("label.cancel") %>
 	</a>
+	
 	<a href="<%= request.getContextPath() %>/open.knowledge/list/<%= jspUtil.out("offset") %><%= jspUtil.out("params") %>"
 		class="btn btn-success" role="button"><i class="fa fa-list-ul"></i>&nbsp;<%= jspUtil.label("label.backlist") %>
 	</a>
@@ -342,6 +347,10 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 <jsp:include page="../../open/emoji/cheatsheet.jsp"></jsp:include>
 <jsp:include page="markdown.jsp"></jsp:include>
 <jsp:include page="../../open/tag/dialog.jsp"></jsp:include>
+
+<form action="<%= request.getContextPath()%>/protect.knowledge/delete" method="post" role="form" id="knowledgeDeleteForm">
+	<input type="hidden" name="knowledgeId" value="<%= jspUtil.out("knowledgeId") %>" id="knowledgeIdForDelete" />
+</form>
 
 </c:param>
 

--- a/src/main/webapp/js/knowledge-edit.js
+++ b/src/main/webapp/js/knowledge-edit.js
@@ -202,6 +202,72 @@ $(document).ready(function() {
 	});
 	changeTemplate();
 	
+	
+	// 保存処理
+	// フォームのサブミットは禁止
+	$('#knowledgeForm').submit(function(event) {
+		console.log('submit');
+		// 操作対象のフォーム要素を取得
+		var $form = $(this);
+		// ページ遷移を禁止して、Ajaxで保存
+		event.preventDefault();
+		
+		// 送信ボタンを取得
+		// （後で使う: 二重送信を防止する。）
+		var $button = $form.find('button');
+		
+		// 送信
+		$.ajax({
+			url: $form.attr('action'),
+			type: $form.attr('method'),
+			data: $form.serialize(),
+			timeout: 10000,  // 単位はミリ秒
+
+			// 送信前
+			beforeSend: function(xhr, settings) {
+				// ボタンを無効化し、二重送信を防止
+				$button.attr('disabled', true);
+			},
+			// 応答後
+			complete: function(xhr, textStatus) {
+				// ボタンを有効化し、再送信を許可
+				$button.attr('disabled', false);
+			},
+			
+			// 通信成功時の処理
+			success: function(result, textStatus, xhr) {
+				// 入力値を初期化
+				console.log(result);
+				$.notify(result.message, 'info');
+				
+				$form.attr('action', _CONTEXT + '/protect.knowledge/update');
+				
+				var knowledgeId = result.result;
+				$('#knowledgeId').val(knowledgeId);
+				$('#knowledgeIdForDelete').val(knowledgeId);
+				$('#savebutton').html('<i class="fa fa-save"></i>&nbsp;' + _LABEL_UPDATE);
+				$('#title_msg').text(_UPDATE_TITLE);
+				$('#deleteButton').removeClass('hide');
+				$('#cancelButton').removeClass('hide');
+				$('#cancelButton').attr('href', _CONTEXT + '/open.knowledge/view/' + knowledgeId);
+			},
+			// 通信失敗時の処理
+			error: function(xhr, textStatus, error) {
+				// 入力値を初期化
+				console.log(xhr.responseJSON);
+				var msg = xhr.responseJSON;
+				if (msg.children) {
+					for (var i = 0; i < msg.children.length; i++) {
+						var child = msg.children[i];
+						console.log(child);
+						$.notify(child.message, 'warn');
+					}
+				}
+			}
+		});
+		return false;
+	});
+	
 });
 
 var getGroups = function(keyword, offset, listId, pageId, selectFunc) {
@@ -397,8 +463,8 @@ var emojiSelect = function(id) {
 function deleteKnowledge() {
 	bootbox.confirm(_CONFIRM, function(result) {
 		if (result) {
-			$('#knowledgeForm').attr('action', _CONTEXT + '/protect.knowledge/delete');
-			$('#knowledgeForm').submit();
+			$('#knowledgeDeleteForm').attr('action', _CONTEXT + '/protect.knowledge/delete');
+			$('#knowledgeDeleteForm').submit();
 		}
 	}); 
 };


### PR DESCRIPTION
- 登録／更新画面をAjaxによる保存に変更し、画面遷移を伴うデータ保存をやめた
    - 画面遷移をしていたために、再度画面を表示する際の情報を再取得しなければならず、処理が複雑になっていた
    - 画面遷移をなくす事で、画面上の情報をリロードする必要がなくなり、処理が簡潔になるので変更
- 画面遷移をしないようにしたので、タグの選択状態のリクエストパラメータは置換されないので、登録後に一覧の戻っても変なタグ選択状態にならないようになった
