### PR TITLE
Webhookの管理画面を追加

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/admin/WebhookControl.java
+++ b/src/main/java/org/support/project/knowledge/control/admin/WebhookControl.java
@@ -1,0 +1,135 @@
+package org.support.project.knowledge.control.admin;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.support.project.common.bean.ValidateError;
+import org.support.project.common.log.Log;
+import org.support.project.common.log.LogFactory;
+import org.support.project.knowledge.config.AppConfig;
+import org.support.project.knowledge.control.Control;
+import org.support.project.knowledge.dao.WebhookConfigsDao;
+import org.support.project.knowledge.entity.WebhookConfigsEntity;
+import org.support.project.knowledge.logic.WebhookLogic;
+import org.support.project.web.annotation.Auth;
+import org.support.project.web.boundary.Boundary;
+import org.support.project.web.control.service.Get;
+import org.support.project.web.control.service.Post;
+import org.support.project.web.dao.ProxyConfigsDao;
+import org.support.project.web.entity.ProxyConfigsEntity;
+
+public class WebhookControl extends Control {
+	/** ログ */
+	private static Log LOG = LogFactory.getLog(WebhookControl.class);
+
+	/**
+	 * 設定画面を表示
+	 * @return
+	 */
+	@Get
+	@Auth(roles="admin")
+	public Boundary config() {
+		WebhookConfigsDao dao = WebhookConfigsDao.get();
+		List<WebhookConfigsEntity> webhookConfigsEntities = dao.selectAll();
+		setAttribute("webhookConfigsEntities", webhookConfigsEntities);
+		setAttribute("webhookConfigsEntitiesCount", webhookConfigsEntities.size());
+		return forward("config.jsp");
+	}
+
+	@Post
+	@Auth(roles="admin")
+	public Boundary save() throws Exception {
+		WebhookConfigsDao dao = WebhookConfigsDao.get();
+
+		String[] hooks = getParam("hooks[]", String[].class);
+		String url = getParam("url");
+
+		Map<String, String> entityParam = new HashMap<String, String>();
+		List<ValidateError> errors = new ArrayList<>();
+
+		if (hooks == null) {
+			WebhookConfigsEntity entity = WebhookConfigsEntity.get();
+			entityParam.put("url", url);
+
+			errors.addAll(entity.validate(entityParam));
+			if (!errors.isEmpty()) {
+				setResult(null, errors);
+				return config();
+			}
+		}
+
+		for (String hook : hooks) {
+			WebhookConfigsEntity entity = WebhookConfigsEntity.get();
+			entityParam.put("hook", hook);
+			entityParam.put("url", url);
+
+			errors.addAll(entity.validate(entityParam));
+			if (!errors.isEmpty()) {
+				setResult(null, errors);
+				return config();
+			}
+
+			entity.setUrl(url);
+			entity.setHook(hook);
+			dao.save(entity);
+		}
+
+		String successMsg = "message.success.save";
+		setResult(successMsg, errors);
+		return config();
+	}
+
+	@Post
+	@Auth(roles="admin")
+	public Boundary test() throws Exception {
+		ProxyConfigsDao proxyConfigDao = ProxyConfigsDao.get();
+		ProxyConfigsEntity proxyConfig = proxyConfigDao.selectOnKey(AppConfig.get().getSystemName());
+
+		WebhookConfigsDao webhookConfigDao = WebhookConfigsDao.get();
+		WebhookConfigsEntity webhookConfig = webhookConfigDao.selectOnKey(new Integer(getParam("hook_id")));
+
+		if (null == webhookConfig) {
+			addMsgError("knowledge.webhook.test.error");
+			return config();
+		}
+
+		try {
+			InputStream is = getClass().getResourceAsStream(webhookConfig.resourcePath());
+			BufferedReader br = new BufferedReader(new InputStreamReader(is));
+			String str;
+			String json = "";
+			while((str = br.readLine()) != null){
+				json += str;
+			}
+
+			WebhookLogic.get().notify(proxyConfig, webhookConfig, json);
+			addMsgInfo("knowledge.webhook.test.success");
+		} catch (Exception e) {
+			LOG.error(e.getMessage());
+			addMsgError("knowledge.webhook.test.error");
+		}
+
+		return config();
+	}
+
+	@Post
+	@Auth(roles="admin")
+	public Boundary delete() throws Exception {
+		WebhookConfigsDao dao = WebhookConfigsDao.get();
+		try {
+			dao.delete(new Integer(getParam("hook_id")));
+
+			addMsgInfo("knowledge.webhook.delete.success");
+		} catch (Exception e) {
+			LOG.error(e.getMessage());
+			addMsgError("knowledge.webhook.delete.error");
+		}
+
+		return config();
+	}
+}

--- a/src/main/java/org/support/project/knowledge/entity/WebhookConfigsEntity.java
+++ b/src/main/java/org/support/project/knowledge/entity/WebhookConfigsEntity.java
@@ -23,8 +23,8 @@ public class WebhookConfigsEntity extends GenWebhookConfigsEntity {
 	private static final long serialVersionUID = 1L;
 
 	/** Hooks */
-	private static final String HOOK_KNOWLEDGES = "knowledges";
-	private static final String HOOK_COMMENTS = "comments";
+	public static final String HOOK_KNOWLEDGES = "knowledges";
+	public static final String HOOK_COMMENTS = "comments";
 
 	/**
 	 * インスタンス取得
@@ -58,5 +58,13 @@ public class WebhookConfigsEntity extends GenWebhookConfigsEntity {
 	public String eventName() {
 		String hook = getHook();
 		return Character.toUpperCase(hook.charAt(0)) + hook.substring(1) + " Events";
+	}
+
+	/**
+	 * リソースのパスを返す
+	 * @return
+	 */
+	public String resourcePath() {
+		return "/org/support/project/knowledge/webhook/" + getHook() + ".json";
 	}
 }

--- a/src/main/java/org/support/project/knowledge/logic/HttpLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/HttpLogic.java
@@ -1,0 +1,114 @@
+package org.support.project.knowledge.logic;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.support.project.common.config.INT_FLAG;
+import org.support.project.common.util.PasswordUtil;
+import org.support.project.common.util.StringUtils;
+import org.support.project.knowledge.config.AuthType;
+import org.support.project.web.entity.ProxyConfigsEntity;
+
+abstract public class HttpLogic {
+	/** HttpClient */
+	protected HttpClient httpclient = null;
+
+	/**
+	 * HttpClientの生成
+	 * @return
+	 * @throws KeyStoreException
+	 * @throws IOException
+	 * @throws CertificateException
+	 * @throws NoSuchAlgorithmException
+	 * @throws UnrecoverableKeyException
+	 * @throws KeyManagementException
+	 * @throws BadPaddingException
+	 * @throws IllegalBlockSizeException
+	 * @throws NoSuchPaddingException
+	 * @throws InvalidKeyException
+	 */
+	protected HttpClient createHttpClient(ProxyConfigsEntity proxyConfig) throws KeyStoreException, NoSuchAlgorithmException,
+		CertificateException, IOException, KeyManagementException, UnrecoverableKeyException, InvalidKeyException, NoSuchPaddingException,
+		IllegalBlockSizeException, BadPaddingException {
+		if (httpclient != null) {
+			return httpclient;
+		}
+
+		DefaultHttpClient httpclient = new DefaultHttpClient();
+		if (proxyConfig == null) {
+			this.httpclient = httpclient;
+			return httpclient;
+		}
+
+		if (StringUtils.isNotEmpty(proxyConfig.getProxyHostName())) {
+			HttpHost proxy = new HttpHost(proxyConfig.getProxyHostName(), proxyConfig.getProxyPortNo());
+			httpclient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+			CredentialsProvider credsProvider = null; //認証プロバイダー
+			if (proxyConfig.getProxyAuthType() != null && proxyConfig.getProxyAuthType().intValue() > AuthType.None.getValue()) {
+				// Proxyに対する認証をセットする
+				String pass = PasswordUtil.decrypt(proxyConfig.getProxyAuthPassword(), proxyConfig.getProxyAuthSalt());
+				credsProvider = new BasicCredentialsProvider();
+				credsProvider.setCredentials(new AuthScope(proxyConfig.getProxyHostName(), proxyConfig.getProxyPortNo()),
+						getCredentials(proxyConfig.getProxyAuthType(), proxyConfig.getProxyAuthUserId(),
+								pass, proxyConfig.getProxyAuthPcName(), proxyConfig.getProxyAuthDomain()));
+				httpclient.setCredentialsProvider(credsProvider);
+			}
+		}
+
+		if (proxyConfig.getThirdPartyCertificate() != null
+				&& proxyConfig.getThirdPartyCertificate() == INT_FLAG.ON.getValue()) {
+			// オレオレ証明証でも全てOKにする
+			TrustStrategy trustStrategy = new TrustStrategy() {
+				@Override
+				public boolean isTrusted(X509Certificate[] chain, String authType)
+						throws CertificateException {
+					return true;
+				}
+			};
+			X509HostnameVerifier hostnameVerifier = new AllowAllHostnameVerifier();
+			SSLSocketFactory socketFactory = new SSLSocketFactory(
+					trustStrategy, hostnameVerifier);
+
+			Scheme sch = new Scheme("https", 443, socketFactory);
+			httpclient.getConnectionManager().getSchemeRegistry().register(sch);
+		}
+
+		this.httpclient = httpclient;
+		return httpclient;
+	}
+
+	/**
+	 * 認証用のCredentialsを生成
+	 * @param authConfigEntity
+	 * @return
+	 */
+	private Credentials getCredentials(int authType, String user, String pass, String pcName, String domain) {
+		if (authType == AuthType.NTLM.getValue()) {
+			return new org.apache.http.auth.NTCredentials(user, pass, pcName, domain);
+		}
+		return new UsernamePasswordCredentials(user, pass);
+	}
+}

--- a/src/main/java/org/support/project/knowledge/logic/WebhookLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/WebhookLogic.java
@@ -1,0 +1,104 @@
+package org.support.project.knowledge.logic;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+
+import org.support.project.common.log.Log;
+import org.support.project.common.log.LogFactory;
+import org.support.project.di.Container;
+import org.support.project.di.DI;
+import org.support.project.di.Instance;
+import org.support.project.knowledge.entity.WebhookConfigsEntity;
+import org.support.project.web.entity.ProxyConfigsEntity;
+
+@DI(instance=Instance.Singleton)
+public class WebhookLogic extends HttpLogic {
+	/** ログ */
+	private static Log log = LogFactory.getLog(WebhookLogic.class);
+
+	public static WebhookLogic get() {
+		return Container.getComp(WebhookLogic.class);
+	}
+
+	/**
+	 * 通知を送る
+	 *
+	 * @param proxyConfig
+	 * @param webhookConfig
+	 * @param json
+	 * @throws Exception
+	 */
+	public void notify(ProxyConfigsEntity proxyConfig, WebhookConfigsEntity webhookConfig, String json) throws Exception {
+		URI uri = new URI(webhookConfig.getUrl());
+
+		// HttpClient生成
+		this.httpclient = createHttpClient(proxyConfig);
+		HttpPost httpPost = new HttpPost(uri);
+		httpPost.addHeader("Content-type", "application/json");
+		httpPost.setEntity(new StringEntity(json, StandardCharsets.UTF_8));
+		try {
+			ResponseHandler<ResponseData> responseHandler = new HttpResponseHandler(uri);
+			HttpResponse response = httpclient.execute(httpPost);
+
+			ResponseData responseData = responseHandler.handleResponse(response);
+			if (responseData.statusCode != HttpStatus.SC_OK) {
+				log.error("Request failed: statusCode -> " + responseData.statusCode);
+			}
+		} catch (Exception e) {
+			// HttpClientをクリア
+			httpPost.abort();
+			httpPost.releaseConnection();
+
+			this.httpclient = null;
+			throw e;
+		} finally {
+			if (this.httpclient != null) {
+				httpPost.abort();
+				httpPost.releaseConnection();
+			}
+		}
+	}
+
+	/**
+	 * ResponseHandlerが返すレスポンスを解析した結果のオブジェクト
+	 *
+	 * @author nagodon
+	 */
+	protected class ResponseData {
+		public Integer statusCode;
+	}
+
+	/**
+	 * HTTPのレスポンスを処理するResponseHandler
+	 *
+	 * @author nagodon
+	 */
+	protected class HttpResponseHandler implements ResponseHandler<ResponseData> {
+		private URI uri;
+
+		/**
+		 * @param url
+		 */
+		public HttpResponseHandler(URI uri) {
+			super();
+			this.uri = uri;
+		}
+
+		@Override
+		public ResponseData handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
+			ResponseData responseData = new ResponseData();
+			StatusLine statusLine = response.getStatusLine();
+			responseData.statusCode = statusLine.getStatusCode();
+			return responseData;
+		}
+	}
+}

--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -98,6 +98,8 @@ label.host=Host
 label.port=Port
 label.auth.id=ID
 label.auth.password=Password
+label.url=URL
+label.hook=Hook
 
 label.public.view=<i class="fa fa-globe"></i>&nbsp;[Public]
 label.protect.view=<i class="fa fa-gavel"></i>&nbsp;[Protection]
@@ -541,6 +543,21 @@ knowledge.proxy.test.type.proxy=Proxyの設定を使ってテスト
 knowledge.proxy.test.type.direct=Proxyを使わずダイレクトに接続するテスト
 knowledge.proxy.test.done=URLの内容を取得しました。下部の結果表示を確認してください。
 knowledge.proxy.msg=Knowledgeの種類が「Bookmark」の場合に、登録したURLに書かれた内容を取得します。この際に利用するProxyを設定します。
+
++knowledge.webhook.title=WebHook Config
++knowledge.webhook.msg=When articles and comments were posted, notify an external servers.
++knowledge.webhook.event.knowledge.title=Knowledge events
++knowledge.webhook.event.knowledge.description=It will hook into this URL when the article was posted.
++knowledge.webhook.event.comment.title=Comment events
++knowledge.webhook.event.comment.description=It will hook into this URL when the comment was posted.
++knowledge.webhook.list.title=Web hooks
++knowledge.webhook.test=Test hook
++knowledge.webhook.confirm.delete=Delete the webhook settings?
++knowledge.webhook.confirm.test=Test the webhook settings?
++knowledge.webhook.delete.error=Failed to delete the webhook settings.
++knowledge.webhook.delete.success=Deleted the setting of Webhooks.
++knowledge.webhook.test.error=Failed to test the webhook settings.
++knowledge.webhook.test.success=Test send of webhook was successful.
 
 knowledge.template.list.label.empty=データが存在しません
 knowledge.template.add.title=テンプレート登録

--- a/src/main/resources/appresource_ja.properties
+++ b/src/main/resources/appresource_ja.properties
@@ -98,6 +98,8 @@ label.host=ホスト
 label.port=ポート
 label.auth.id=認証用ID
 label.auth.password=認証用パスワード
+label.url=URL
+label.hook=Hook
 
 label.public.view=<i class="fa fa-globe"></i>&nbsp;[公開]
 label.protect.view=<i class="fa fa-gavel"></i>&nbsp;[保護]
@@ -541,6 +543,21 @@ knowledge.proxy.test.type.proxy=Proxyの設定を使ってテスト
 knowledge.proxy.test.type.direct=Proxyを使わずダイレクトに接続するテスト
 knowledge.proxy.test.done=URLの内容を取得しました。下部の結果表示を確認してください。
 knowledge.proxy.msg=Knowledgeの種類が「Bookmark」の場合に、登録したURLに書かれた内容を取得します。この際に利用するProxyを設定します。
+
+knowledge.webhook.title=WebHook 設定
+knowledge.webhook.msg=記事やコメントが投稿された時に外部のサーバに情報を通知することができます
+knowledge.webhook.event.knowledge.title=ナレッジイベント
+knowledge.webhook.event.knowledge.description=記事が投稿された際にこのURLにフックされます
+knowledge.webhook.event.comment.title=コメントイベント
+knowledge.webhook.event.comment.description=コメントが投稿された際にこのURLにフックされます
+knowledge.webhook.list.title=Web hooks
+knowledge.webhook.test=Test hook
+knowledge.webhook.confirm.delete=Webhookの設定を本当に削除しますか?
+knowledge.webhook.confirm.test=Webhookの設定をテストしますか?
+knowledge.webhook.delete.error=Webhookの設定の削除に失敗しました
+knowledge.webhook.delete.success=Webhookの設定を削除しました
+knowledge.webhook.test.error=Webhookのテスト送信に失敗しました
+knowledge.webhook.test.success=Webhookのテスト送信に成功しました
 
 knowledge.template.list.label.empty=データが存在しません
 knowledge.template.add.title=テンプレート登録

--- a/src/main/resources/org/support/project/knowledge/webhook/comments.json
+++ b/src/main/resources/org/support/project/knowledge/webhook/comments.json
@@ -1,0 +1,28 @@
+{
+	"comment_no": 1,
+	"comment": "記事へのコメント",
+	"status": "created",
+	"insert_user": "コメント投稿ユーザ名",
+	"insert_date": "コメント投稿日",
+	"update_user": "コメント更新ユーザ名",
+	"update_date": "コメント更新日",
+	"knowledge": {
+		"knowledge_id": 1,
+		"title": "記事タイトル",
+		"content": "記事本文",
+		"public_flag": 10,
+		"tags": [
+			"Sample"
+		],
+		"groups": [
+			"ALL USERS"
+		],
+		"like_count": 2,
+		"comment_count": 3,
+		"type_id": -100,
+		"insert_user": "記事投稿ユーザ名",
+		"insert_date": "記事投稿日",
+		"update_user": "記事更新ユーザ名",
+		"update_date": "記事更新日"
+	}
+}

--- a/src/main/resources/org/support/project/knowledge/webhook/knowledges.json
+++ b/src/main/resources/org/support/project/knowledge/webhook/knowledges.json
@@ -1,0 +1,20 @@
+{
+	"knowledge_id": 1,
+	"title": "記事タイトル",
+	"content": "記事本文",
+	"status": "created",
+	"public_flag": 10,
+	"tags": [
+		"Sample"
+	],
+	"groups": [
+		"ALL USERS"
+	],
+	"like_count": 2,
+	"comment_count": 3,
+	"type_id": -100,
+	"insert_user": "記事投稿ユーザ名",
+	"insert_date": "記事投稿日",
+	"update_user": "記事更新ユーザ名",
+	"update_date": "記事更新日"
+}

--- a/src/main/webapp/WEB-INF/views/admin/webhook/config.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/webhook/config.jsp
@@ -1,0 +1,103 @@
+<%@page import="org.support.project.web.util.JspUtil"%>
+<%@page pageEncoding="UTF-8" isELIgnored="false" session="false" errorPage="/WEB-INF/views/commons/errors/jsp_error.jsp"%>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
+<%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+
+<% JspUtil jspUtil = new JspUtil(request, pageContext); %>
+
+<c:import url="/WEB-INF/views/commons/layout/layoutMain.jsp">
+
+<c:param name="PARAM_HEAD">
+<style>
+.pull-right {
+	margin-left: 5px;
+}
+</style>
+</c:param>
+
+<c:param name="PARAM_SCRIPTS">
+<script>
+function deleteConfig(hookId) {
+	$('input:hidden[name=hook_id]').val(hookId);
+	bootbox.confirm('<%= jspUtil.label("knowledge.webhook.confirm.delete") %>', function(result) {
+		if (result) {
+			var $form = $("#webhookForm");
+			$form.attr('action', '<%= request.getContextPath()%>/admin.webhook/delete');
+			$form.submit();
+		}
+	});
+};
+
+function testConfig(hookId) {
+	$('input:hidden[name=hook_id]').val(hookId);
+	bootbox.confirm('<%= jspUtil.label("knowledge.webhook.confirm.test") %>', function(result) {
+		if (result) {
+			var $form = $("#webhookForm");
+			$form.attr('action', '<%= request.getContextPath()%>/admin.webhook/test');
+			$form.submit();
+		}
+	});
+};
+</script>
+</c:param>
+<c:param name="PARAM_CONTENT">
+<h4 class="title"><%= jspUtil.label("knowledge.webhook.title") %></h4>
+<div class="alert alert-info alert-dismissible" role="alert">
+	<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	<%= jspUtil.label("knowledge.webhook.msg") %><br/>
+</div>
+<form action="<%= request.getContextPath()%>/admin.webhook/save" method="post" role="form"class="form-horizontal">
+	<div class="form-group">
+		<label for="url" class="col-sm-2 control-label"><%= jspUtil.label("label.url") %></label>
+		<div class="col-sm-8">
+			<input type="text" class="form-control" name="url" id="url" placeholder="http://example.jp/post.json" value="<%= jspUtil.out("webHookUrl") %>" />
+		</div>
+	</div>
+	<div class="form-group">
+		<label for="knowledges" class="col-sm-2 control-label"><%= jspUtil.label("label.hook") %></label>
+		<div class="col-sm-8">
+			<div>
+				<input type="checkbox" class="pull-left" name="hooks[]" id="knowledges" value="knowledges" checked/>
+				<div class="prepend-left-20">
+					<label class="list-label"><strong><%= jspUtil.label("knowledge.webhook.event.knowledge.title") %></strong></label>
+					<p class="light"><%= jspUtil.label("knowledge.webhook.event.knowledge.description") %></p>
+				</div>
+			</div>
+			<div>
+				<input type="checkbox" class="pull-left" name="hooks[]" id="comments" value="comments" />
+				<div class="prepend-left-20">
+					<label class="list-label"><strong><%= jspUtil.label("knowledge.webhook.event.comment.title") %></strong></label>
+					<p class="light"><%= jspUtil.label("knowledge.webhook.event.comment.description") %></p>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="form-group">
+		<div class="col-sm-offset-2 col-sm-10">
+			<button type="submit" class="btn btn-primary"><i class="fa fa-add"></i>&nbsp;<%= jspUtil.label("label.add") %></button>
+		</div>
+	</div>
+</form>
+<div class="panel panel-default">
+	<div class="panel-heading"><%= jspUtil.label("knowledge.webhook.list.title") %>(<%= jspUtil.out("webhookConfigsEntitiesCount") %>)</div>
+	<ul class="list-group">
+		<c:forEach var="webhookConfigsEntity" items="${webhookConfigsEntities}">
+		<li class="list-group-item">
+			<div class="pull-right">
+				<a class="btn btn-danger pull-right" href="javascript:void(0);" onclick="deleteConfig(<%= jspUtil.out("webhookConfigsEntity.hookId") %>)"><%= jspUtil.label("label.delete") %></a>
+				<a class="btn btn-default pull-right" href="javascript:void(0);" onclick="testConfig(<%= jspUtil.out("webhookConfigsEntity.hookId") %>)"><%= jspUtil.label("knowledge.webhook.test") %></a>
+			</div>
+			<div class="clearfix">
+				<span class="h4" style="font-family: monospace;"><%= jspUtil.out("webhookConfigsEntity.url") %></span>
+			</div>
+			<p><span class="label label-default h5"><%= jspUtil.out("webhookConfigsEntity.eventName()") %></span></p>
+		</li>
+		</c:forEach>
+	</ul>
+</div>
+<form id="webhookForm" method="post">
+	<input type="hidden" name="hook_id" value="">
+</form>
+</c:param>
+</c:import>

--- a/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
+++ b/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
@@ -148,7 +148,12 @@
 								<i class="fa fa-globe"></i>&nbsp;<%= jspUtil.label("knowledge.proxy.title") %>
 							</a>
 						</li>
-						
+							<li >
+							<a href="<%= request.getContextPath() %>/admin.webhook/config" style="cursor: pointer;">
+								<i class="fa fa-link"></i>&nbsp;<%= jspUtil.label("knowledge.webhook.title") %>
+							</a>
+						</li>
+
 						<li class="dropdown-header">&nbsp;<%= jspUtil.label("knowledge.navbar.data") %></li>
 						<li >
 							<a href="<%= request.getContextPath() %>/admin.database/index" style="cursor: pointer;">


### PR DESCRIPTION
#69 の管理画面追加PRです。
次のPRで実際にWebhookを実行するバッチあげます。

Proxyを通したHTTP通信を再利用したかったのでCrawlerLogicからクライアント作成ロジックを
切り出してHttpLogicとして抽象スーパークラスとしました。

一応bookmarkのFileParseBatが正常に実行されるのは確認してますが
もしお手数でなければ一度手元にpullしてご確認いただけるとありがたいです。

よろしくお願いします。