### PR TITLE
記事本文の視認性と可読性を上げる

### DIFF
--- a/src/main/webapp/WEB-INF/views/open/knowledge/view.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/view.jsp
@@ -125,6 +125,7 @@ Knowledge - [<%= jspUtil.out("knowledgeId") %>] <%= jspUtil.out("title", JspUtil
 
 			
 			<%-- 添付ファイル --%>
+			<!-- Issue 123 に同意。添付ファイルは編集時に確認できれば良いと思います。
 			<c:forEach var="file" items="${files}" >
 				<c:if test="${file.commentNo == 0}">
 				<div class="downloadfile">
@@ -135,6 +136,10 @@ Knowledge - [<%= jspUtil.out("knowledgeId") %>] <%= jspUtil.out("title", JspUtil
 				</div>
 				</c:if>
 			</c:forEach>
+			 -->
+
+
+
 			
 		</div>
 		

--- a/src/main/webapp/css/knowledge-view.css
+++ b/src/main/webapp/css/knowledge-view.css
@@ -12,6 +12,9 @@
 	cursor: text;
 }
 
+#content {
+	margin-top: 16px;
+}
 #content_head {}
 #content_main {}
 #template_items_area {

--- a/src/main/webapp/css/markdown.css
+++ b/src/main/webapp/css/markdown.css
@@ -26,6 +26,7 @@
 .markdown h6 {
 	margin: 20px 0 10px;
 	padding: 0;
+	padding-bottom: 8px;
 	font-weight: bold;
 	-webkit-font-smoothing: antialiased;
 	cursor: text;
@@ -80,7 +81,8 @@
 
 .markdown h2 {
 	font-size: 24px;
-	border-bottom: 1px solid #cccccc;
+	margin-top: 40px;
+	border-bottom: 1px solid #dddddd;
 	color: black;
 }
 
@@ -103,12 +105,21 @@
 
 .markdown p,
 .markdown blockquote,
-.markdown ul,
-.markdown ol,
 .markdown dl,
-.markdown li,
 .markdown table{
 	margin: 15px 0;
+}
+
+.markdown ul,
+.markdown ol,
+.markdown li {}
+
+.markdown p,
+.markdown blockquote,
+.markdown li,
+.markdown dt,
+.markdown table{
+	line-height: 2.0em;
 }
 
 .markdown hr {


### PR DESCRIPTION
行間の調整が主な作業です。参考にbefore/afterの画像を添付します。

また、#123 も取り入れました。

**Before**

![before](https://cloud.githubusercontent.com/assets/15374413/12161056/0e31bc00-b535-11e5-8205-9fd675e2997c.png)

**After**

![after](https://cloud.githubusercontent.com/assets/15374413/12161055/0e2aa8b6-b535-11e5-973c-81b9b8d79f79.png)

サンプルだと、変更点が少しわかりにくいかもしれませんが、実際に使っているような記事を表示してみると、違いがよりわかりやすく感じられると思います。

よろしくお願いします。