### PR TITLE
#240 タグ入力のライブラリを以前動作させていたバージョンに戻した

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "marked": "0.3.4",
     "highlightjs": "8.9.1",
     "bootbox": "4.4.0",
-    "bootstrap-tagsinput": "0.5.0",
+    "bootstrap-tagsinput": "0.4.2",
     "bootstrap3-typeahead": "3.1.1",
     "bootstrap-fileinput": "4.2.8",
     "jquery-file-upload": "9.11.2",


### PR DESCRIPTION
bootstrap-tagsinputをv0.7系まで利用していたバージョンに戻したところ、
#240 の問題が発生しないことを確認しました。