### PR TITLE
Fix/issue257 data not found

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/protect/FileControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/FileControl.java
@@ -69,7 +69,7 @@ public class FileControl extends Control {
 	
 	
 	@Get
-	public JsonBoundary delete() {
+	public JsonBoundary delete() throws Exception {
 		LOG.trace("delete()");
 		
 		Long fileNo = getParam("fileNo", Long.class);

--- a/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
@@ -345,7 +345,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
 			return devolution(HttpMethod.get, "open.Knowledge/view", String.valueOf(knowledgeId));
 		}
 		LOG.trace("save");
-		knowledgeLogic.delete(knowledgeId, getLoginedUser());
+		knowledgeLogic.delete(knowledgeId);
 		
 		addMsgSuccess("message.success.delete");
 		return super.devolution(HttpMethod.get, "open.Knowledge/list");

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -923,8 +923,9 @@ public class KnowledgeLogic {
 	 * @throws Exception 
 	 */
 	@Aspect(advice=org.support.project.ormapping.transaction.Transaction.class)
-	public void delete(Long knowledgeId, LoginedUser loginedUser) throws Exception {
-		//ナレッジ削除(通常のdeleteは、論理削除になる → 管理者は見える)
+	public void delete(Long knowledgeId) throws Exception {
+		LOG.info("delete Knowledge: " + knowledgeId);
+		//ナレッジ削除(通常のdeleteは、論理削除になる)
 		knowledgesDao.delete(knowledgeId);
 		
 		// アクセス権削除
@@ -935,6 +936,9 @@ public class KnowledgeLogic {
 		
 		// 添付ファイルを削除
 		fileLogic.deleteOnKnowledgeId(knowledgeId);
+		
+		// コメント削除
+		this.deleteCommentsOnKnowledgeId(knowledgeId);
 		
 		// ナレッジにアクセス可能なグループ削除
 		GroupLogic.get().removeKnowledgeGroup(knowledgeId);
@@ -951,6 +955,15 @@ public class KnowledgeLogic {
 	}
 	
 	/**
+	 * ナレッジに紐づくコメントを削除
+	 * @param knowledgeId
+	 */
+	private void deleteCommentsOnKnowledgeId(Long knowledgeId) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	/**
 	 * ユーザのナレッジを削除
 	 * TODO ものすごく多くのナレッジを登録したユーザの場合、それを全て削除するのは時間がかかるかも？
 	 * ただ、非同期で実施して、「そのうち消えます」と表示するのも気持ち悪いと感じられるので、
@@ -962,19 +975,8 @@ public class KnowledgeLogic {
 		// ユーザのナレッジを取得
 		List<Long> knowledgeIds = knowledgesDao.selectOnUser(loginUserId);
 		for (Long knowledgeId : knowledgeIds) {
-			LOG.warn(knowledgeId);
-			// アクセス権削除
-			knowledgeUsersDao.deleteOnKnowledgeId(knowledgeId);
-			// タグを削除
-			knowledgeTagsDao.deleteOnKnowledgeId(knowledgeId);
+			delete(knowledgeId);
 		}
-		// ユーザが登録したナレッジを削除
-		knowledgesDao.deleteOnUser(loginUserId);
-		
-		//全文検索エンジンから削除
-		IndexLogic indexLogic = IndexLogic.get();
-		indexLogic.deleteOnUser(loginUserId);
-
 	}
 	
 	/**

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -680,6 +680,10 @@ public class KnowledgeLogic {
 				KnowledgeFilesEntity filesEntity = filesDao.selectOnKeyWithoutBinary(fileNo);
 				if (filesEntity != null && filesEntity.getKnowledgeId() != null) {
 					KnowledgesEntity entity = knowledgesDao.selectOnKeyWithUserName(filesEntity.getKnowledgeId());
+					if (entity == null) {
+						// 添付ファイルの情報が検索エンジン内にあり、検索にHitしたが、それに紐づくナレッジデータは削除されていた
+						break;
+					}
 					entity.setTitle(entity.getTitle());
 					
 					StringBuilder builder = new StringBuilder();
@@ -705,6 +709,10 @@ public class KnowledgeLogic {
 				CommentsEntity commentsEntity = CommentsDao.get().selectOnKey(commentNo);
 				if (commentsEntity != null && commentsEntity.getKnowledgeId() != null) {
 					KnowledgesEntity entity = knowledgesDao.selectOnKeyWithUserName(commentsEntity.getKnowledgeId());
+					if (entity == null) {
+						// コメントの情報が検索エンジン内にあり、検索にHitしたが、それに紐づくナレッジデータは削除されていた
+						break;
+					}
 					entity.setTitle(entity.getTitle());
 					
 					StringBuilder builder = new StringBuilder();

--- a/src/main/java/org/support/project/knowledge/logic/UploadedFileLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/UploadedFileLogic.java
@@ -16,7 +16,7 @@ import org.support.project.di.DI;
 import org.support.project.di.Instance;
 import org.support.project.knowledge.dao.KnowledgeFilesDao;
 import org.support.project.knowledge.entity.KnowledgeFilesEntity;
-import org.support.project.knowledge.entity.KnowledgesEntity;
+import org.support.project.knowledge.indexer.IndexingValue;
 import org.support.project.knowledge.vo.UploadFile;
 import org.support.project.web.bean.LoginedUser;
 
@@ -93,9 +93,10 @@ public class UploadedFileLogic {
 	 * @param fileNos
 	 * @param loginedUser
 	 * @param commentNo 
+	 * @throws Exception 
 	 */
 	@Aspect(advice=org.support.project.ormapping.transaction.Transaction.class)
-	public void setKnowledgeFiles(Long knowledgeId, List<Long> fileNos, LoginedUser loginedUser) {
+	public void setKnowledgeFiles(Long knowledgeId, List<Long> fileNos, LoginedUser loginedUser) throws Exception {
 		// 現在、すでに紐づいている添付ファイルを取得
 		List<KnowledgeFilesEntity> filesEntities = filesDao.selectOnKnowledgeId(knowledgeId);
 		Map<Long, KnowledgeFilesEntity> filemap = new HashMap<>();
@@ -122,7 +123,9 @@ public class UploadedFileLogic {
 			Long fileNo = (Long) iterator.next();
 			//filesDao.delete(fileNo);
 			filesDao.physicalDelete(fileNo); // バイナリは大きいので、物理削除する
-			// TODO 全文検索エンジンから情報を削除
+			// 全文検索エンジンから情報を削除
+			IndexLogic indexLogic = IndexLogic.get();
+			indexLogic.delete("FILE-" + fileNo);
 		}
 	}
 	
@@ -139,9 +142,10 @@ public class UploadedFileLogic {
 	 * @param fileNos
 	 * @param loginedUser
 	 * @param commentNo 
+	 * @throws Exception 
 	 */
 	@Aspect(advice=org.support.project.ormapping.transaction.Transaction.class)
-	public void setKnowledgeFiles(Long knowledgeId, List<Long> fileNos, LoginedUser loginedUser, Long commentNo) {
+	public void setKnowledgeFiles(Long knowledgeId, List<Long> fileNos, LoginedUser loginedUser, Long commentNo) throws Exception {
 		// 現在、すでに紐づいている添付ファイルを取得
 		List<KnowledgeFilesEntity> filesEntities = filesDao.selectOnKnowledgeId(knowledgeId);
 		Map<Long, KnowledgeFilesEntity> filemap = new HashMap<>();
@@ -167,7 +171,10 @@ public class UploadedFileLogic {
 			Long fileNo = (Long) iterator.next();
 			//filesDao.delete(fileNo);
 			filesDao.physicalDelete(fileNo); // バイナリは大きいので、物理削除する
-			// TODO 全文検索エンジンから情報を削除
+			
+			// 全文検索エンジンから情報を削除
+			IndexLogic indexLogic = IndexLogic.get();
+			indexLogic.delete("FILE-" + fileNo);
 		}
 	}	
 	
@@ -176,12 +183,15 @@ public class UploadedFileLogic {
 	 * ファイルを削除する
 	 * @param fileNo
 	 * @param loginedUser 
+	 * @throws Exception 
 	 */
-	public void removeFile(Long fileNo, LoginedUser loginedUser) {
+	public void removeFile(Long fileNo, LoginedUser loginedUser) throws Exception {
 		// DBのデータを削除
 		filesDao.physicalDelete(fileNo); // バイナリは大きいので、物理削除する
 		
-		// TODO 全文検索エンジンから情報を削除
+		// 全文検索エンジンから情報を削除
+		IndexLogic indexLogic = IndexLogic.get();
+		indexLogic.delete("FILE-" + fileNo);
 	}
 
 	/**
@@ -235,13 +245,15 @@ public class UploadedFileLogic {
 	/**
 	 * ナレッジを削除する際に、添付ファイルを削除
 	 * @param knowledgeId
+	 * @throws Exception 
 	 */
-	public void deleteOnKnowledgeId(Long knowledgeId) {
+	public void deleteOnKnowledgeId(Long knowledgeId) throws Exception {
 		List<KnowledgeFilesEntity> filesEntities = filesDao.selectOnKnowledgeId(knowledgeId);
 		for (KnowledgeFilesEntity entity : filesEntities) {
 			filesDao.physicalDelete(entity.getFileNo());
-			//TODO 全文検索エンジンからも情報を削除
-			
+			// 全文検索エンジンから情報を削除
+			IndexLogic indexLogic = IndexLogic.get();
+			indexLogic.delete("FILE-" + entity.getFileNo());
 		}
 	}
 	


### PR DESCRIPTION
- コメントや添付ファイルの情報が検索エンジンに登録されている時に、それのナレッジ情報が削除されていた場合にエラーにならないようにする	
- ナレッジ削除時に、添付ファイルの情報を全文検索エンジンから削除するように修正
- ナレッジを削除する際に、そのナレッジに紐づくコメントを削除していなかったので削除するように修正