### PR TITLE
bookmarkなknowledgeでコンテンツ取得エラーの際のログにURLを出力するようにした

### DIFF
--- a/src/main/java/org/support/project/knowledge/logic/CrawlerLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/CrawlerLogic.java
@@ -98,7 +98,7 @@ public class CrawlerLogic extends HttpLogic {
 				response = httpclient.execute(httpGet);
 			} catch (IllegalStateException e) {
 				//HttpGetが何らかのエラーを返したので、このアイテムの取得終了
-				log.error("http get error.   -->" + e.getMessage());
+				log.error("http get error.   -->" + url + "  : " + e.getMessage());
 				// HttpClientをクリア
 				httpGet.abort();
 				httpGet.releaseConnection();


### PR DESCRIPTION
なんで検索にひっかからないの？という問い合わせの解析のため。
ちなみに、SSL証明書が不正だった。