### PR TITLE
詳細、編集画面のtitleタグの先頭に記事タイトルを持ってくるように

### DIFF
--- a/src/main/webapp/WEB-INF/views/open/knowledge/view.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/view.jsp
@@ -51,7 +51,7 @@ var _SET_IMAGE_LABEL= '<%= jspUtil.label("knowledge.edit.set.image.path") %>';
 </c:param>
 
 <c:param name="PARAM_PAGE_TITLE">
-Knowledge - [<%= jspUtil.out("knowledgeId") %>] <%= jspUtil.out("title", JspUtil.ESCAPE_CLEAR) %>
+<%= jspUtil.out("title", JspUtil.ESCAPE_CLEAR) %> - Knowledge
 </c:param>
 
 

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/view_edit.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/view_edit.jsp
@@ -57,8 +57,9 @@ _TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
 
 </c:param>
 
-
-
+<c:param name="PARAM_PAGE_TITLE">
+<%= jspUtil.label("label.update") %> - <%= jspUtil.out("title", JspUtil.ESCAPE_CLEAR) %> - Knowledge
+</c:param>
 
 <c:param name="PARAM_CONTENT">
 <h4 class="title" id="title_msg"><%= jspUtil.label("knowledge.edit.title") %></h4>


### PR DESCRIPTION
#277 の対応になります。
ナレッジのIDを表示するとその分領域を削ってしまうため削除しました。