### PR TITLE
squid:S106 - Standard outputs should not be used directly to log anything

### DIFF
--- a/src/main/java/org/support/project/knowledge/bat/AbstractBat.java
+++ b/src/main/java/org/support/project/knowledge/bat/AbstractBat.java
@@ -47,7 +47,7 @@ public abstract class AbstractBat {
 	}
 	
 	protected void send(String msg) {
-		System.out.println("[SEND]" + msg);
+		LOG.info("[SEND]" + msg);
 	}
 
 }

--- a/src/main/java/org/support/project/knowledge/bat/DataTransferBat.java
+++ b/src/main/java/org/support/project/knowledge/bat/DataTransferBat.java
@@ -46,7 +46,7 @@ public class DataTransferBat extends AbstractBat implements Runnable {
 		} catch (Exception e) {
 			LOG.error(e);
 		}
-		System.out.println("Database stop.");
+		LOG.info("Database stop.");
 	}
 
 	/**

--- a/src/main/java/org/support/project/knowledge/bat/ReIndexingBat.java
+++ b/src/main/java/org/support/project/knowledge/bat/ReIndexingBat.java
@@ -3,6 +3,8 @@ package org.support.project.knowledge.bat;
 import java.util.List;
 
 import org.apache.commons.lang.ClassUtils;
+import org.support.project.common.log.Log;
+import org.support.project.common.log.LogFactory;
 import org.support.project.knowledge.config.AppConfig;
 import org.support.project.knowledge.config.SystemConfig;
 import org.support.project.knowledge.dao.KnowledgesDao;
@@ -13,6 +15,8 @@ import org.support.project.web.entity.SystemConfigsEntity;
 
 
 public class ReIndexingBat extends AbstractBat {
+	
+	private static Log LOG = LogFactory.getLog(ReIndexingBat.class);
 	
 	public static void main(String[] args) throws Exception {
 		initLogName("ReIndexingBat.log");
@@ -49,7 +53,7 @@ public class ReIndexingBat extends AbstractBat {
 	 * @param str
 	 */
 	private void out(String str) {
-		System.out.println("[SEND]" + str);
+		LOG.info("[SEND]" + str);
 	}
 	
 }

--- a/src/main/java/org/support/project/knowledge/listener/GlobalInitializationListener.java
+++ b/src/main/java/org/support/project/knowledge/listener/GlobalInitializationListener.java
@@ -34,7 +34,7 @@ public class GlobalInitializationListener implements ServletContextListener {
 		FileAppender appendar= (FileAppender) log.getAppender("APP_FILEOUT");
 		appendar.setFile(logDir + "/app.log");
 		appendar.activateOptions();//変更の反映
-		System.out.println("[APP LOG] " + logDir.getAbsolutePath() + "/app.log");
+		LOG.info("[APP LOG] " + logDir.getAbsolutePath() + "/app.log");
 		LOG.info(logDir.getAbsolutePath());
 	}
 	

--- a/src/main/java/org/support/project/knowledge/logic/DataTransferLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/DataTransferLogic.java
@@ -60,13 +60,13 @@ public class DataTransferLogic {
 		SystemsEntity systemEntity = systemsDao.selectOnKey(AppConfig.get().getSystemName());
 		if (systemEntity == null) {
 			// Systemバージョン情報が無い未初期化のDBからコピーしてもしょうがない
-			System.out.println("Data transfer is failed.");
+			LOG.info("Data transfer is failed.");
 			return;
 		}
 		String version = systemEntity.getVersion();
 		if (!InitDB.CURRENT.equals(version)) {
 			// コピー元のDBのバージョンが古い（なんかおかしい）
-			System.out.println("Data transfer is failed.");
+			LOG.info("Data transfer is failed.");
 			return;
 		}
 		
@@ -115,7 +115,7 @@ public class DataTransferLogic {
 		// データコピー
 		for (Class class1 : targets) {
 			if (AbstractDao.class.isAssignableFrom(class1)) {
-				System.out.println("Data transfer : " + class1.getName());
+				LOG.info("Data transfer : " + class1.getName());
 				Object dao = Container.getComp(class1);
 				// From からデータ取得
 				Method setConnectionNameMethods = class1.getMethod("setConnectionName", String.class);

--- a/src/main/java/org/support/project/knowledge/logic/MarkdownLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/MarkdownLogic.java
@@ -165,7 +165,7 @@ public class MarkdownLogic {
 		ScriptEngineManager manager = new ScriptEngineManager();
 		engine = manager.getEngineByName("js");
 		if (engine == null) {
-			System.out.println("JavaScriptはサポート外");
+			LOG.info("JavaScriptはサポート外");
 			initEngine = true;
 			return null;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S106 - Standard outputs should not be used directly to log anything.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS106
Please let me know if you have any questions.
George Kankava