### PR TITLE
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
@@ -208,15 +208,15 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		String tags = super.getParam("tagNames");
 		List<TagsEntity> tagList = knowledgeLogic.manegeTags(tags);
 		
-		entity = knowledgeLogic.insert(entity, tagList, fileNos, groups, editors, template, super.getLoginedUser());
-		setAttributeOnProperty(entity);
+		KnowledgesEntity insertedEntity = knowledgeLogic.insert(entity, tagList, fileNos, groups, editors, template, super.getLoginedUser());
+		setAttributeOnProperty(insertedEntity);
 		
-		List<UploadFile> files = fileLogic.selectOnKnowledgeIdWithoutCommentFiles(entity.getKnowledgeId(), getRequest().getContextPath());
+		List<UploadFile> files = fileLogic.selectOnKnowledgeIdWithoutCommentFiles(insertedEntity.getKnowledgeId(), getRequest().getContextPath());
 		setAttribute("files", files);
 		
 		addMsgSuccess("message.success.insert");
 //		return forward("view_edit.jsp");
-		return sendMsg(MessageStatus.Success, HttpStatus.SC_200_OK, String.valueOf(entity.getKnowledgeId()), "message.success.insert");
+		return sendMsg(MessageStatus.Success, HttpStatus.SC_200_OK, String.valueOf(insertedEntity.getKnowledgeId()), "message.success.insert");
 	}
 	
 	/**
@@ -294,15 +294,15 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		String tags = super.getParam("tagNames");
 		List<TagsEntity> tagList = knowledgeLogic.manegeTags(tags);
 		
-		entity = knowledgeLogic.update(entity, tagList, fileNos, groups, editors, template, super.getLoginedUser());
-		setAttributeOnProperty(entity);
+		KnowledgesEntity updatedEntity = knowledgeLogic.update(entity, tagList, fileNos, groups, editors, template, super.getLoginedUser());
+		setAttributeOnProperty(updatedEntity);
 		addMsgSuccess("message.success.update");
 		
-		List<UploadFile> files = fileLogic.selectOnKnowledgeIdWithoutCommentFiles(entity.getKnowledgeId(), getRequest().getContextPath());
+		List<UploadFile> files = fileLogic.selectOnKnowledgeIdWithoutCommentFiles(updatedEntity.getKnowledgeId(), getRequest().getContextPath());
 		setAttribute("files", files);
 		
 		// return forward("view_edit.jsp");
-		return sendMsg(MessageStatus.Success, HttpStatus.SC_200_OK, String.valueOf(entity.getKnowledgeId()), "message.success.update");
+		return sendMsg(MessageStatus.Success, HttpStatus.SC_200_OK, String.valueOf(updatedEntity.getKnowledgeId()), "message.success.update");
 	}
 	
 	/**

--- a/src/main/java/org/support/project/knowledge/logic/GroupLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/GroupLogic.java
@@ -43,16 +43,16 @@ public class GroupLogic {
 	@Aspect(advice=org.support.project.ormapping.transaction.Transaction.class)
 	public GroupsEntity addGroup(GroupsEntity groupsEntity, LoginedUser loginedUser) {
 		ExGroupsDao groupsDao = ExGroupsDao.get();
-		groupsEntity = groupsDao.insert(groupsEntity);
+		GroupsEntity insertedEntity = groupsDao.insert(groupsEntity);
 		
 		UserGroupsDao userGroupsDao = UserGroupsDao.get();
 		UserGroupsEntity userGroupsEntity = new UserGroupsEntity(
-				groupsEntity.getGroupId(), 
+				insertedEntity.getGroupId(), 
 				loginedUser.getUserId());
 		userGroupsEntity.setGroupRole(CommonWebParameter.GROUP_ROLE_ADMIN);
 		userGroupsDao.insert(userGroupsEntity);
 		
-		return groupsEntity;
+		return insertedEntity;
 	}
 	
 	/**
@@ -69,8 +69,7 @@ public class GroupLogic {
 				return null; // アクセス権がないユーザ
 			}
 		}
-		groupsEntity = groupsDao.save(groupsEntity);
-		return groupsEntity;
+		return groupsDao.save(groupsEntity);
 	}
 	
 	/**

--- a/src/main/java/org/support/project/knowledge/logic/KeywordLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KeywordLogic.java
@@ -46,10 +46,9 @@ public class KeywordLogic {
 	 * @return String
 	 */
 	public String parseKeyword(String text) {
-		text = text.replaceAll(KeywordLogic.regexList.get("groups"), "");
-		text = text.replaceAll(KeywordLogic.regexList.get("tags"), "");
-		text = text.trim();
-		return text;
+		String parsedText = text.replaceAll(KeywordLogic.regexList.get("groups"), "");
+		parsedText = parsedText.replaceAll(KeywordLogic.regexList.get("tags"), "");
+		return parsedText.trim();
 	}
 
 	/**

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -145,28 +145,28 @@ public class KnowledgeLogic {
 			List<LabelValue> targets, List<LabelValue> editors, TemplateMastersEntity template,
 			LoginedUser loginedUser) throws Exception {
 		// ナレッジを登録
-		entity = knowledgesDao.insert(entity);
+		KnowledgesEntity insertedEntity = knowledgesDao.insert(entity);
 		// アクセス権を登録
-		saveAccessUser(entity, loginedUser, targets);
+		saveAccessUser(insertedEntity, loginedUser, targets);
 		// 編集権を登録
-		saveEditorsUser(entity, loginedUser, editors);
+		saveEditorsUser(insertedEntity, loginedUser, editors);
 		// タグを登録
-		setTags(entity, tags);
+		setTags(insertedEntity, tags);
 		// 添付ファイルを更新（紐付けをセット）
-		fileLogic.setKnowledgeFiles(entity.getKnowledgeId(), fileNos, loginedUser);
+		fileLogic.setKnowledgeFiles(insertedEntity.getKnowledgeId(), fileNos, loginedUser);
 		// 拡張項目の保存
-		saveTemplateItemValue(entity.getKnowledgeId(), template, loginedUser);
+		saveTemplateItemValue(insertedEntity.getKnowledgeId(), template, loginedUser);
 		
 		// 全文検索エンジンへ登録
-		saveIndex(entity, tags, targets, template, loginedUser.getUserId());
+		saveIndex(insertedEntity, tags, targets, template, loginedUser.getUserId());
 		// 一覧表示用の情報を更新
-		updateKnowledgeExInfo(entity);
+		updateKnowledgeExInfo(insertedEntity);
 		// 履歴登録
-		insertHistory(entity);
+		insertHistory(insertedEntity);
 		// 通知（TODO 別スレッド化を検討）
-		NotifyLogic.get().notifyOnKnowledgeInsert(entity);
+		NotifyLogic.get().notifyOnKnowledgeInsert(insertedEntity);
 		
-		return entity;
+		return insertedEntity;
 	}
 
 	
@@ -187,46 +187,46 @@ public class KnowledgeLogic {
 			List<LabelValue> targets, List<LabelValue> editors, TemplateMastersEntity template,
 			LoginedUser loginedUser) throws Exception {
 		// ナレッッジを更新
-		entity = knowledgesDao.update(entity);
+		KnowledgesEntity updatedEntity = knowledgesDao.update(entity);
 		// ユーザのアクセス権を解除
-		knowledgeUsersDao.deleteOnKnowledgeId(entity.getKnowledgeId());
+		knowledgeUsersDao.deleteOnKnowledgeId(updatedEntity.getKnowledgeId());
 		// グループとナレッジのヒモ付を解除
 		GroupLogic groupLogic = GroupLogic.get();
-		groupLogic.removeKnowledgeGroup(entity.getKnowledgeId());
+		groupLogic.removeKnowledgeGroup(updatedEntity.getKnowledgeId());
 		// 編集権限を削除
 		KnowledgeEditUsersDao editUsersDao = KnowledgeEditUsersDao.get();
 		KnowledgeEditGroupsDao editGroupsDao = KnowledgeEditGroupsDao.get();
-		editUsersDao.deleteOnKnowledgeId(entity.getKnowledgeId());
-		editGroupsDao.deleteOnKnowledgeId(entity.getKnowledgeId());
+		editUsersDao.deleteOnKnowledgeId(updatedEntity.getKnowledgeId());
+		editGroupsDao.deleteOnKnowledgeId(updatedEntity.getKnowledgeId());
 		
 		// アクセス権を登録
-		saveAccessUser(entity, loginedUser, targets);
+		saveAccessUser(updatedEntity, loginedUser, targets);
 		// 編集権を登録
-		saveEditorsUser(entity, loginedUser, editors);
+		saveEditorsUser(updatedEntity, loginedUser, editors);
 		
 		// タグを登録
-		knowledgeTagsDao.deleteOnKnowledgeId(entity.getKnowledgeId());
-		setTags(entity, tags);
+		knowledgeTagsDao.deleteOnKnowledgeId(updatedEntity.getKnowledgeId());
+		setTags(updatedEntity, tags);
 		
 		// 拡張項目の保存
-		saveTemplateItemValue(entity.getKnowledgeId(), template, loginedUser);
+		saveTemplateItemValue(updatedEntity.getKnowledgeId(), template, loginedUser);
 		
 		// 添付ファイルを更新（紐付けをセット）
-		fileLogic.setKnowledgeFiles(entity.getKnowledgeId(), fileNos, loginedUser);
+		fileLogic.setKnowledgeFiles(updatedEntity.getKnowledgeId(), fileNos, loginedUser);
 		
 		// 全文検索エンジンへ登録
-		saveIndex(entity, tags, targets, template, entity.getInsertUser());
+		saveIndex(updatedEntity, tags, targets, template, updatedEntity.getInsertUser());
 		
 		// 一覧表示用の情報を更新
-		updateKnowledgeExInfo(entity);
+		updateKnowledgeExInfo(updatedEntity);
 		
 		// 履歴登録
-		insertHistory(entity);
+		insertHistory(updatedEntity);
 
 		// 通知（TODO 別スレッド化を検討）
-		NotifyLogic.get().notifyOnKnowledgeUpdate(entity);
+		NotifyLogic.get().notifyOnKnowledgeUpdate(updatedEntity);
 		
-		return entity;
+		return updatedEntity;
 	}
 	
 	/**
@@ -1111,15 +1111,15 @@ public class KnowledgeLogic {
 	 */
 	public void updateComment(CommentsEntity commentsEntity, List<Long> fileNos, LoginedUser loginedUser) throws Exception {
 		CommentsDao commentsDao = CommentsDao.get();
-		commentsEntity = commentsDao.update(commentsEntity);
+		CommentsEntity updatedCommentsEntity = commentsDao.update(commentsEntity);
 		// 一覧表示用の情報を更新
-		KnowledgeLogic.get().updateKnowledgeExInfo(commentsEntity.getKnowledgeId());
+		KnowledgeLogic.get().updateKnowledgeExInfo(updatedCommentsEntity.getKnowledgeId());
 
 		// 検索エンジンに追加
-		addIndexOnComment(commentsEntity);
+		addIndexOnComment(updatedCommentsEntity);
 		
 		// 添付ファイルを更新（紐付けをセット）
-		fileLogic.setKnowledgeFiles(commentsEntity.getKnowledgeId(), fileNos, loginedUser, commentsEntity.getCommentNo());
+		fileLogic.setKnowledgeFiles(updatedCommentsEntity.getKnowledgeId(), fileNos, loginedUser, updatedCommentsEntity.getCommentNo());
 	}
 	
 

--- a/src/main/java/org/support/project/knowledge/logic/TemplateLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/TemplateLogic.java
@@ -88,11 +88,11 @@ public class TemplateLogic {
 	public TemplateMastersEntity addTemplate(TemplateMastersEntity template, LoginedUser loginedUser) {
 		TemplateMastersDao templateDao = TemplateMastersDao.get();
 		// テンプレート保存
-		template = templateDao.insert(template);
-		Integer typeId = template.getTypeId();
+		TemplateMastersEntity insertedTemplate = templateDao.insert(template);
+		Integer typeId = insertedTemplate.getTypeId();
 		// テンプレートの入力項目を保存
-		insertItems(template, typeId);
-		return template;
+		insertItems(insertedTemplate, typeId);
+		return insertedTemplate;
 	}
 	
 	/**

--- a/src/main/java/org/support/project/knowledge/parser/impl/TextParser.java
+++ b/src/main/java/org/support/project/knowledge/parser/impl/TextParser.java
@@ -37,14 +37,10 @@ public class TextParser implements Parser {
 		BufferedReader reader = null;
 		List<Sentence> sentenceInFileVos = new ArrayList<Sentence>();
 		try {
-			if (StringUtils.isEmpty(encode)) {
-				// 文字コードの判定
-				encode = this.getEncoding(file);
-			}
 			
 			reader = new BufferedReader(
 					new InputStreamReader(
-							new FileInputStream(file), encode));
+							new FileInputStream(file), StringUtils.isEmpty(encode) ? this.getEncoding(file) : encode));
 			String line;
 			int count = 1;
 			// 読み込みデータがなくなるまで、読み込み


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1226
https://dev.eclipse.org/sonar/coding_rules#q=S1488|rule_key=squid%3AS1488
Please let me know if you have any questions.
George Kankava

