### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/support/project/knowledge/dao/KnowledgesDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/KnowledgesDao.java
@@ -20,6 +20,12 @@ public class KnowledgesDao extends GenKnowledgesDao {
 
 	/** SerialVersion */
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * ID 
+	 */
+	private int currentId = 0;
+
 	/**
 	 * インスタンス取得
 	 * AOPに対応
@@ -28,12 +34,6 @@ public class KnowledgesDao extends GenKnowledgesDao {
 	public static KnowledgesDao get() {
 		return Container.getComp(KnowledgesDao.class);
 	}
-
-
-	/**
-	 * ID 
-	 */
-	private int currentId = 0;
 
 	/**
 	 * IDを採番 

--- a/src/main/java/org/support/project/knowledge/dao/NotifyConfigsDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/NotifyConfigsDao.java
@@ -14,6 +14,12 @@ public class NotifyConfigsDao extends GenNotifyConfigsDao {
 
 	/** SerialVersion */
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * ID 
+	 */
+	private int currentId = 0;
+
 	/**
 	 * インスタンス取得
 	 * AOPに対応
@@ -22,12 +28,6 @@ public class NotifyConfigsDao extends GenNotifyConfigsDao {
 	public static NotifyConfigsDao get() {
 		return Container.getComp(NotifyConfigsDao.class);
 	}
-
-
-	/**
-	 * ID 
-	 */
-	private int currentId = 0;
 
 	/**
 	 * IDを採番 

--- a/src/main/java/org/support/project/knowledge/dao/TagsDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/TagsDao.java
@@ -20,6 +20,12 @@ public class TagsDao extends GenTagsDao {
 
 	/** SerialVersion */
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * ID 
+	 */
+	private int currentId = 0;
+
 	/**
 	 * インスタンス取得
 	 * AOPに対応
@@ -28,12 +34,6 @@ public class TagsDao extends GenTagsDao {
 	public static TagsDao get() {
 		return Container.getComp(TagsDao.class);
 	}
-
-
-	/**
-	 * ID 
-	 */
-	private int currentId = 0;
 
 	/**
 	 * IDを採番 

--- a/src/main/java/org/support/project/knowledge/dao/TemplateMastersDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/TemplateMastersDao.java
@@ -21,6 +21,11 @@ public class TemplateMastersDao extends GenTemplateMastersDao {
 	public static final int TYPE_ID_KNOWLEDGE = -100;
 	public static final int TYPE_ID_BOOKMARK = -99;
 
+	/**
+	 * ID 
+	 */
+	private int currentId = 0;
+
 	/** SerialVersion */
 	private static final long serialVersionUID = 1L;
 	/**
@@ -31,11 +36,6 @@ public class TemplateMastersDao extends GenTemplateMastersDao {
 	public static TemplateMastersDao get() {
 		return Container.getComp(TemplateMastersDao.class);
 	}
-
-	/**
-	 * ID 
-	 */
-	private int currentId = 0;
 
 	/**
 	 * IDを採番 

--- a/src/main/java/org/support/project/knowledge/dao/WebhookConfigsDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/WebhookConfigsDao.java
@@ -17,6 +17,12 @@ public class WebhookConfigsDao extends GenWebhookConfigsDao {
 
 	/** SerialVersion */
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * ID 
+	 */
+	private int currentId = 0;
+
 	/**
 	 * インスタンス取得
 	 * AOPに対応
@@ -25,11 +31,6 @@ public class WebhookConfigsDao extends GenWebhookConfigsDao {
 	public static WebhookConfigsDao get() {
 		return Container.getComp(WebhookConfigsDao.class);
 	}
-
-	/**
-	 * ID 
-	 */
-	private int currentId = 0;
 
 	/**
 	 * IDを採番 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava