### PR TITLE
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/src/main/java/org/support/project/knowledge/entity/TemplateItemsEntity.java
+++ b/src/main/java/org/support/project/knowledge/entity/TemplateItemsEntity.java
@@ -89,11 +89,9 @@ public class TemplateItemsEntity extends GenTemplateItemsEntity {
 	protected String convLabelName(String label) {
 		Resources resources = ThreadResources.get().getResources();
 		if ("Item Name".equals(label)) {
-			String resource = resources.getResource("knowledge.template.label.item.title");
-			return resource;
+			return resources.getResource("knowledge.template.label.item.title");
 		} else if ("Description".equals(label)) {
-			String resource = resources.getResource("knowledge.template.label.item.description");
-			return resource;
+			return resources.getResource("knowledge.template.label.item.description");
 		}
 		return label;
 	}

--- a/src/main/java/org/support/project/knowledge/entity/TemplateMastersEntity.java
+++ b/src/main/java/org/support/project/knowledge/entity/TemplateMastersEntity.java
@@ -69,14 +69,11 @@ public class TemplateMastersEntity extends GenTemplateMastersEntity {
 	protected String convLabelName(String label) {
 		Resources resources = ThreadResources.get().getResources();
 		if ("Type Name".equals(label)) {
-			String resource = resources.getResource("knowledge.template.label.name");
-			return resource;
+			return resources.getResource("knowledge.template.label.name");
 		} else if ("Type Icon".equals(label)) {
-			String resource = resources.getResource("knowledge.template.label.icon");
-			return resource;
+			return resources.getResource("knowledge.template.label.icon");
 		} else if ("Description".equals(label)) {
-			String resource = resources.getResource("knowledge.template.label.description");
-			return resource;
+			return resources.getResource("knowledge.template.label.description");
 		}
 		return label;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava