### PR TITLE
Multiple code improvements - squid:S1068, squid:S1905

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/protect/ConfigControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/ConfigControl.java
@@ -1,7 +1,5 @@
 package org.support.project.knowledge.control.protect;
 
-import org.support.project.common.log.Log;
-import org.support.project.common.log.LogFactory;
 import org.support.project.di.DI;
 import org.support.project.di.Instance;
 import org.support.project.knowledge.control.Control;
@@ -10,8 +8,6 @@ import org.support.project.web.control.service.Get;
 
 @DI(instance=Instance.Prototype)
 public class ConfigControl extends Control {
-	/** ログ */
-	private static Log LOG = LogFactory.getLog(ConfigControl.class);
 	
 	@Get
 	public Boundary index() {

--- a/src/main/java/org/support/project/knowledge/control/protect/GroupControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/GroupControl.java
@@ -6,15 +6,11 @@ import java.util.Map;
 
 import org.support.project.common.bean.ValidateError;
 import org.support.project.common.exception.ParseException;
-import org.support.project.common.log.Log;
-import org.support.project.common.log.LogFactory;
 import org.support.project.common.util.RandomUtil;
 import org.support.project.common.util.StringUtils;
 import org.support.project.di.DI;
 import org.support.project.di.Instance;
 import org.support.project.knowledge.control.Control;
-import org.support.project.knowledge.dao.TagsDao;
-import org.support.project.knowledge.entity.TagsEntity;
 import org.support.project.knowledge.logic.GroupLogic;
 import org.support.project.knowledge.vo.GroupUser;
 import org.support.project.web.bean.LabelValue;
@@ -33,8 +29,6 @@ import org.support.project.web.exception.InvalidParamException;
 
 @DI(instance=Instance.Prototype)
 public class GroupControl extends Control {
-	/** ログ */
-	private static Log LOG = LogFactory.getLog(GroupControl.class);
 	
 	public static final int PAGE_LIMIT = 10;
 	

--- a/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/KnowledgeControl.java
@@ -405,7 +405,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
 			List<UploadFile> files = fileLogic.selectOnFileNos(fileNos, getRequest().getContextPath());
 			Iterator<UploadFile> iterator = files.iterator();
 			while (iterator.hasNext()) {
-				UploadFile uploadFile = (UploadFile) iterator.next();
+				UploadFile uploadFile = iterator.next();
 				if (uploadFile.getKnowlegeId() != null) {
 					// 新規登録なのに、添付ファイルが既にナレッジに紐づいている（おかしい）
 					iterator.remove();
@@ -517,7 +517,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
 		List<UploadFile> files = fileLogic.selectOnFileNos(fileNos, getRequest().getContextPath());
 		Iterator<UploadFile> iterator = files.iterator();
 		while (iterator.hasNext()) {
-			UploadFile uploadFile = (UploadFile) iterator.next();
+			UploadFile uploadFile = iterator.next();
 			if (uploadFile.getKnowlegeId() != null) {
 				// 新規登録なのに、添付ファイルが既にナレッジに紐づいている（おかしい）
 				iterator.remove();
@@ -629,7 +629,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
 				Stock stock = new Stock();
 				Iterator<String> keys = map.keySet().iterator();
 				while (keys.hasNext()) {
-					String key = (String) keys.next();
+					String key = keys.next();
 					Object value = map.get(key);
 					if (LOG.isTraceEnabled()) {
 						LOG.trace(key + " = " + value + "  (" + value.getClass().getName() + ")");

--- a/src/main/java/org/support/project/knowledge/control/protect/StockControl.java
+++ b/src/main/java/org/support/project/knowledge/control/protect/StockControl.java
@@ -6,8 +6,6 @@ import java.util.List;
 import net.arnx.jsonic.JSONException;
 
 import org.support.project.common.bean.ValidateError;
-import org.support.project.common.log.Log;
-import org.support.project.common.log.LogFactory;
 import org.support.project.di.DI;
 import org.support.project.di.Instance;
 import org.support.project.knowledge.control.Control;
@@ -24,8 +22,6 @@ import org.support.project.web.exception.InvalidParamException;
 
 @DI(instance=Instance.Prototype)
 public class StockControl extends Control {
-	/** ログ */
-	private static Log LOG = LogFactory.getLog(StockControl.class);
 	
 	private static final int LIST_LIMIT = 20;
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1068 - Unused private fields should be removed.
squid:S1905 - Redundant casts should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1905
Please let me know if you have any questions.
George Kankava