### PR TITLE
Heroku Buttonの設置

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java $JAVA_OPTS -jar target/dependency/webapp-runner.jar --port $PORT target/*.war

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
    - [id/password] user2 / user2
    - [id/password] user3 / user3
 
+### Deploy to Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/kaakaa/knowledge/tree/heroku)
 
 #### Project website (more info)
 - https://support-project.org/knowledge_info/index

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "knowledge",
+  "description": "Free Knowledge Management System",
+  "keywords": [
+    "knowledge",
+    "java"
+  ],
+  "website": "https://github.com/support-project/knowledge",
+  "repository": "git://github.com/support-project/knowledge.git",
+  "success_url": "/index"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "knowledge",
+  "version": "1.0.0",
+  "description": "Free Knowledge Management System",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/support-project/knowledge"
+  },
+  "dependencies": {
+    "bower": "^1.7.9",
+    "npm": "^3.3.12"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "knowledge"
+  ],
+  "bugs": {
+    "url": "https://github.com/support-project/knowledge/issues"
+  },
+  "author": "support-project",
+  "license": "Apache-2.0"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,27 @@
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>copy</goal></goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.github.jsimone</groupId>
+                                    <artifactId>webapp-runner</artifactId>
+                                    <version>8.0.30.2</version>
+                                    <destFileName>webapp-runner.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,41 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>0.0.27</version>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v5.3.0</nodeVersion>
+                            <npmVersion>3.3.12</npmVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm install bower</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bower install</id>
+                        <goals>
+                            <goal>bower</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
#329 にて、デモ環境の問題があったようなので、Heroku ButtonでHerokuへ簡単にデプロイできるようにしてみました。
[kaakaa/knowledge at heroku](https://github.com/kaakaa/knowledge/tree/heroku) より試せます。

Heroku上でのknowledge.warの起動にはWebapp Runnerを使用しています。
[Deploying Tomcat-based Java Web Applications with Webapp Runner | Heroku Dev Center](https://devcenter.heroku.com/articles/java-webapp-runner#deploying-with-the-heroku-maven-plugin)

もし、マージしていただける場合は、`README.md`に書かれているHeroku Buttonのリンクを修正するよう留意ください。

`[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/kaakaa/knowledge/tree/heroku)`
↓
`[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/support-project/knowledge)`

* * * 

また、Herokuへデプロイする際はHeroku上のMavenビルドで`bower install`を行わなくてはならなかったため、#342 にも対応しています。
私の開発環境では、node/npm/bower共にインストール済みですが、[eirslett/frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin)は特に問題なく動作しました。

ただ、`maven package`にてnpm installによるbowerのインストールとbowerインストールを行っているため、ビルドにかかる時間が長くなっています。

* * *

容易なデモ環境構築のためにHeroku Buttonを設置するのが目的でしたが、いろいろな部分をイジってしまったためマージせずに何かの参考にしていただくだけでも構いません。
