### PR TITLE
Feature/issue354 link to setuppage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
-## knowledge [![Build Status](https://travis-ci.org/support-project/knowledge.svg?branch=master)](https://travis-ci.org/support-project/knowledge)
+# Knowledge
 
-===============
-
-### Free Knowledge Management System
+[![Build Status](https://travis-ci.org/support-project/knowledge.svg?branch=master)](https://travis-ci.org/support-project/knowledge)
 
 
-#### Live Demo
-- https://support-project.org/knowledge/index
+## About
+- Free Knowledge Management System
+
+
+## Live Demo
+- [https://support-project.org/knowledge/index](https://support-project.org/knowledge/index)
 - Demo users
    - [id/password] user1 / user1
    - [id/password] user2 / user2
    - [id/password] user3 / user3
 
-### Deploy to Heroku
+
+## Deploy to Heroku
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/support-project/knowledge)
 
-#### Project website (more info)
-- https://support-project.org/knowledge_info/index
+
+## How to initial set up
+- Please show the [wiki page](https://github.com/support-project/knowledge/wiki)
+
+
+## Project website (more info)
+- [landing page](https://support-project.org/knowledge_info/index)
+- [online manual](https://support-project.org/knowledge_info/open.manual/index)
+
 
 
 

--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -152,6 +152,7 @@ knowledge.navbar.search=Advanced search
 knowledge.footer.about=About
 knowledge.footer.list=List
 knowledge.footer.license=License
+knowledge.footer.manual=Manual
 
 knowledge.auth.description=Prompts for sign-in is required functions.<br/>(Such as knowledge of editing is required sign-in)
 knowledge.auth.signin=Sign In

--- a/src/main/resources/appresource_ja.properties
+++ b/src/main/resources/appresource_ja.properties
@@ -152,6 +152,7 @@ knowledge.navbar.search=詳細検索
 knowledge.footer.about=Knowledgeとは
 knowledge.footer.list=一覧
 knowledge.footer.license=ライセンス
+knowledge.footer.manual=オンラインマニュアル
 
 knowledge.auth.description=サインインが必要な機能です。<br/>(ナレッジの編集などはサインインが必要です)
 knowledge.auth.signin=サインイン実行

--- a/src/main/webapp/WEB-INF/views/commons/layout/commonFooter.jsp
+++ b/src/main/webapp/WEB-INF/views/commons/layout/commonFooter.jsp
@@ -12,11 +12,9 @@
 			<li class="first">
 				<a class="" href="<%= request.getContextPath() %>/index" style="cursor: pointer;"> <%= jspUtil.label("knowledge.footer.about") %></a>
 			</li>
-			<%--
 			<li>
-				<a class="" href="<%= request.getContextPath() %>/open.knowledge/list" style="cursor: pointer;"> <%= jspUtil.label("knowledge.footer.list") %></a>
+				<a class="" href="https://support-project.org/knowledge_info/open.manual/index" style="cursor: pointer;"> <%= jspUtil.label("knowledge.footer.manual") %></a>
 			</li>
-			--%>
 			<li>
 				<a class="" href="<%= request.getContextPath() %>/open.license" style="cursor: pointer;"> <%= jspUtil.label("knowledge.footer.license") %></a>
 			</li>


### PR DESCRIPTION
- トップページのREADME.mdにセットアップ情報を書いたWikiページへのリンクを記載
- Knowledgeのフッターメニューにオンラインマニュアルページへのリンクを追加