### PR TITLE
Fix/issue86 mailhook

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/admin/MailhookControl.java
+++ b/src/main/java/org/support/project/knowledge/control/admin/MailhookControl.java
@@ -104,6 +104,7 @@ public class MailhookControl extends Control {
             entity.setMailPass(PasswordUtil.encrypt(entity.getMailPass(), salt));
             entity.setMailPassSalt(salt);
         }
+        entity.setHookId(MailhookLogic.MAIL_HOOK_ID);
         MailHooksDao.get().save(entity);
         setAttributeOnProperty(entity);
         

--- a/src/main/java/org/support/project/knowledge/dao/MailHooksDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/MailHooksDao.java
@@ -1,10 +1,14 @@
 package org.support.project.knowledge.dao;
 
+import java.sql.Timestamp;
+
+import org.support.project.common.config.INT_FLAG;
 import org.support.project.di.Container;
 import org.support.project.di.DI;
 import org.support.project.di.Instance;
-
 import org.support.project.knowledge.dao.gen.GenMailHooksDao;
+import org.support.project.knowledge.entity.MailHooksEntity;
+import org.support.project.ormapping.common.DBUserPool;
 
 /**
  * 受信したメールからの処理
@@ -44,5 +48,26 @@ public class MailHooksDao extends GenMailHooksDao {
         return currentId;
     }
 
+    /* (non-Javadoc)
+     * @see org.support.project.knowledge.dao.gen.GenMailHooksDao#save(org.support.project.knowledge.entity.MailHooksEntity)
+     */
+    @Override
+    public MailHooksEntity save(MailHooksEntity entity) {
+        if (entity.getHookId() != null) {
+            MailHooksEntity db = physicalSelectOnKey(entity.getHookId());
+            if (db != null) {
+                physicalDelete(entity.getHookId());
+            }
+            entity.setDeleteFlag(INT_FLAG.OFF.getValue());
+            entity.setInsertUser((Integer) DBUserPool.get().getUser());
+            entity.setInsertDatetime(new Timestamp(new java.util.Date().getTime()));
+            return rawPhysicalInsert(entity);
+        } else {
+            return super.save(entity);
+        }
+    }
+    
+    
+    
 
 }

--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -700,5 +700,8 @@ knowledge.admin.mailhook.condition.info.user.2=User number, please check the men
 knowledge.admin.mailhook.condition.process.user.kind=Select register user
 knowledge.admin.mailhook.condition.process.user.kind.1=From mail address(if not exists, register by default user)
 knowledge.admin.mailhook.condition.process.user.kind.2=Default register user
+knowledge.admin.mailhook.info.1=Post from e-mail is a automation function for add knowledge. It is receive mail by regularly, and add knowledge if satisfy the conditions.
+knowledge.admin.mailhook.info.2=After the reception, all mails will delete in this mailbox.
+knowledge.admin.mailhook.info.3=For this reason, please prepare the e-mail address of this function only.
 
 

--- a/src/main/resources/appresource_ja.properties
+++ b/src/main/resources/appresource_ja.properties
@@ -700,3 +700,8 @@ knowledge.admin.mailhook.condition.info.user.2=ユーザ番号は、システム
 knowledge.admin.mailhook.condition.process.user.kind=投稿者の選択
 knowledge.admin.mailhook.condition.process.user.kind.1=メール送信者のユーザ(メール送信者のユーザが見つからない場合、デフォルトユーザで登録)
 knowledge.admin.mailhook.condition.process.user.kind.2=常にデフォルトユーザで登録
+knowledge.admin.mailhook.info.1=メールから投稿は以下に設定したメールボックスで受信したメールを定期的に受信し、条件にあったメールをKnowledgeに投稿する機能です。
+knowledge.admin.mailhook.info.2=定期的に受信するメールボックスに届いたメールは、受信後に削除します。
+knowledge.admin.mailhook.info.3=このため、メール投稿専用のメールアドレスを用意してください。
+
+

--- a/src/main/webapp/WEB-INF/views/admin/mailhook/config.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/mailhook/config.jsp
@@ -30,6 +30,17 @@ function deleteMail() {
 <c:param name="PARAM_CONTENT">
 <h4 class="title"><%= jspUtil.label("knowledge.admin.post.from.mail") %></h4>
 
+<div class="alert alert-info alert-dismissible" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <strong>Information</strong><br/>
+    <%=jspUtil.label("knowledge.admin.mailhook.info.1")%>
+    <%=jspUtil.label("knowledge.admin.mailhook.info.2")%><br/>
+    <strong><%=jspUtil.label("knowledge.admin.mailhook.info.3")%><br/></strong>
+</div>
+
+
 <form action="<%= request.getContextPath()%>/admin.mailhook/save" method="post" role="form" id="mailForm">
     
     <h5 class="sub_title"><%= jspUtil.label("knowledge.mail.subtitle.param") %></h5>


### PR DESCRIPTION
- メールからの投稿時に、メール投稿条件に複数に合致する場合、閲覧範囲の設定を追加するように変更
   - 例えば複数のメーリングリストに投稿した場合、複数の閲覧権限を付けるように修正
- メールから投稿の機能で設定するメールボックスで受信したメールは、受信後に削除するので、メールから投稿専用のメールアドレスを用意するように、インフォメーション表示するようにした