### PR TITLE
Modify Sanitize process that outputs a unc path.

### DIFF
--- a/src/test/java/org/support/project/knowledge/logic/MarkdownLogicTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/MarkdownLogicTest.java
@@ -243,4 +243,27 @@ public class MarkdownLogicTest extends TestCommon {
         }
     }
 
+    
+
+    @Test
+    @Order(order = 9)
+    public void testUNC()
+            throws ParseException, UnsupportedEncodingException, IOException, TransformerFactoryConfigurationError, TransformerException {
+        String markdown = "[UNCPathLink](\\\\hoge\\data, \"UNCPathLink\")";
+        String html = "<p><a href=\"\\\\hoge\\data,\" title=\"UNCPathLink\" rel=\"nofollow\">UNCPathLink</a></p>\n";
+        String result = MarkdownLogic.get().markdownToHtml(markdown, MarkdownLogic.ENGINE_MARKEDJ).getHtml();
+        try {
+            org.junit.Assert.assertEquals(html, result);
+        } catch (AssertionError e) {
+            LOG.info("testMarkdJDel");
+            LOG.info("[Markdown] : " + markdown);
+            LOG.info("[Html]     : " + html);
+            LOG.info("[Parsed]   : " + result);
+            LOG.info("[Indent]   : " + SanitizingLogic.get().indent(result));
+            throw e;
+        }
+    }
+    
+    
+    
 }


### PR DESCRIPTION
UNCパスや、file:// 、smb:// へのリンクが、サニタイズの処理の中で消していたため、
出力できるように修正した。（webモジュールの修正で、テストを追加したのみ）