### PR TITLE
Add test for amp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.support-project</groupId>
             <artifactId>markedj</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/org/support/project/knowledge/logic/MarkdownLogicTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/MarkdownLogicTest.java
@@ -264,6 +264,27 @@ public class MarkdownLogicTest extends TestCommon {
         }
     }
     
+
+    
+    @Test
+    @Order(order = 10)
+    public void testAmp()
+            throws ParseException, UnsupportedEncodingException, IOException, TransformerFactoryConfigurationError, TransformerException {
+        String markdown = "```\n&read_data\n```";
+        String html = "<pre><code>&amp;read_data\n</code></pre>\n";
+        String result = MarkdownLogic.get().markdownToHtml(markdown, MarkdownLogic.ENGINE_MARKEDJ).getHtml();
+        try {
+            org.junit.Assert.assertEquals(html, result);
+        } catch (AssertionError e) {
+            LOG.info("testMarkdJDel");
+            LOG.info("[Markdown] : " + markdown);
+            LOG.info("[Html]     : " + html);
+            LOG.info("[Parsed]   : " + result);
+            LOG.info("[Indent]   : " + SanitizingLogic.get().indent(result));
+            throw e;
+        }
+    }
+    
     
     
 }


### PR DESCRIPTION
Markdownのパース処理の中で、「＆」の置換を間違えていたので、Markdownパーサーの方を修正した。
それに伴い、参照先のライブラリバージョンの更新とテストを追記した。
