### PR TITLE
Add slide paginate key event

### DIFF
--- a/src/main/webapp/js/slide.js
+++ b/src/main/webapp/js/slide.js
@@ -134,4 +134,22 @@ function showSlides(n, slideId) {
     indexMap[slideId] = slideIndex;
 }
 
+$(document).on({
+	'mouseenter': function () {
+		var id = $(this).attr('id');
+		$(window).on('keypress', function (e) {
+			e.preventDefault();
 
+			if (37 == e.keyCode) {
+				plusSlides(-1, id);
+			}
+
+			if (39 == e.keyCode) {
+				plusSlides(1, id);
+			}
+		});
+	},
+	'mouseleave': function () {
+		$(window).off('keypress');
+	}
+}, '.slideshow-area');


### PR DESCRIPTION
社内でスライドのページネーション操作をキーボードで行いたいという要望があったため実装してみました。
複数のスライドが表示されることを想定してマウスカーソルがスライド内にある場合のみそのスライドのページネーション操作をできるようにしています。
