### PR TITLE
Fixed like http method

### DIFF
--- a/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
@@ -574,7 +574,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
      * @return
      * @throws InvalidParamException
      */
-    @Get
+    @Post
     public Boundary like() throws InvalidParamException {
         Long knowledgeId = super.getPathLong(Long.valueOf(-1));
         KnowledgeLogic knowledgeLogic = KnowledgeLogic.get();

--- a/src/main/webapp/js/knowledge-view.js
+++ b/src/main/webapp/js/knowledge-view.js
@@ -17,7 +17,7 @@ $(document).ready(function(){
 var addlike = function(knowledgeId) {
     var url = _CONTEXT + '/open.knowledge/like/' + knowledgeId;
     $.ajax({
-        type : 'GET',
+        type : 'POST',
         url : url,
         success : function(data, dataType) {
             console.log(data);


### PR DESCRIPTION
現状だとGETでできてしまうため、ブラウザ上でリンクを何回もF5アタックする等で不用意にいいねがついてしまうのでPOSTに変更しました。