### PR TITLE
Fix auto-completed tagnames and groupnames are html-escaped.

### DIFF
--- a/src/main/webapp/WEB-INF/views/open/knowledge/search.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/search.jsp
@@ -32,13 +32,17 @@
 
 <script>
 var _TAGS = [];
+var tagname;
 <c:forEach var="tagitem" items="${tagitems}" varStatus="status">
-_TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
+tagname = unescapeHTML('<%= jspUtil.out("tagitem.tagName") %>');
+_TAGS.push(tagname);
 </c:forEach>
 
 var _GROUPS = [];
+var groupname;
 <c:forEach var="groupitem" items="${groupitems}" varStatus="status">
-_GROUPS.push('<%= jspUtil.out("groupitem.groupName") %>');
+groupname = unescapeHTML('<%= jspUtil.out("groupitem.groupName") %>');
+_GROUPS.push(groupname);
 </c:forEach>
 </script>
 

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/partials/partials-edit-scripts.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/partials/partials-edit-scripts.jsp
@@ -68,8 +68,10 @@ var _ANSWER_DATETIME = '<%= jspUtil.label("knowledge.survey.label.answer.date") 
 var _ANSWER_USER = '<%= jspUtil.label("knowledge.survey.label.answer.user") %>';
 
 var _TAGS = [];
+var tagname;
 <c:forEach var="tagitem" items="${tagitems}" varStatus="status">
-_TAGS.push('<%= jspUtil.out("tagitem.tagName") %>');
+tagname = unescapeHTML('<%= jspUtil.out("tagitem.tagName") %>');
+_TAGS.push(tagname);
 </c:forEach>
 </script>
 

--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -66,6 +66,16 @@ function isString(obj) {
     return typeof (obj) == "string" || obj instanceof String;
 };
 
+function unescapeHTML(str) {
+    var div = document.createElement("div");
+    div.innerHTML = str.replace(/</g,"&lt;")
+                       .replace(/>/g,"&gt;")
+                       .replace(/ /g, "&nbsp;")
+                       .replace(/\r/g, "&#13;")
+                       .replace(/\n/g, "&#10;");
+    return div.textContent || div.innerText;
+};
+
 var handleErrorResponse = function(xhr, textStatus, error) {
     console.log(error);
     console.log(xhr);

--- a/src/main/webapp/js/knowledge-target-select.js
+++ b/src/main/webapp/js/knowledge-target-select.js
@@ -165,7 +165,7 @@ var viewEditor = function() {
     for (var i = 0; i < selectedEditors.length; i++) {
         var item = selectedEditors[i];
         values.push(item.value);
-        labels.push(item.label);
+        labels.push(unescapeHTML(item.label));
     }
     if (selectedEditors.length == 0) {
         $('#clearSelectedEditor').hide();


### PR DESCRIPTION
#271 に関連して、タグ名とグループ名が自動補完された場合に文字参照で補完されてしまうのを修正しました。

unescapeHTML 関数については、[こちら](http://blog.tojiru.net/article/211339637.html)のコードを利用させて頂いています。

いろいろ触ってみて気づいた箇所を修正しましたが、他にも修正するべき点がありましたらご指摘ください。