### PR TITLE
#731 fix unauthorized items are listed when user searchs with tag names.

### DIFF
--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -540,7 +540,7 @@ public class KnowledgeLogic {
         }
 
         // グループが指定されてる場合はグループのみ対象にして検索する
-        if (groups != null) {
+        if (groups != null && !groups.isEmpty()) {
             for (GroupsEntity groupsEntity : groups) {
                 searchingValue.addGroup(groupsEntity.getGroupId());
             }

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -541,8 +541,23 @@ public class KnowledgeLogic {
 
         // グループが指定されてる場合はグループのみ対象にして検索する
         if (groups != null && !groups.isEmpty()) {
+            boolean exit = false;
             for (GroupsEntity groupsEntity : groups) {
-                searchingValue.addGroup(groupsEntity.getGroupId());
+                // 指定のグループは、自分が所属しているグループかどうか
+                List<GroupsEntity> logiedUserGroups = loginedUser.getGroups();
+                if (logiedUserGroups != null && !logiedUserGroups.isEmpty()) {
+                    for (GroupsEntity userGroup : logiedUserGroups) {
+                        if (userGroup.getGroupId().intValue() == groupsEntity.getGroupId().intValue()) {
+                            searchingValue.addGroup(groupsEntity.getGroupId());
+                            exit = true;
+                        }
+                    }
+                }
+            }
+            if (!exit) {
+                // 権限の無いグループの情報を参照しようとしているので、検索できないようにする
+                LOG.warn("Bad request group param");
+                searchingValue.addTag(-123); //ありえないタグで検索するので、絶対に何もヒットしない
             }
             return searchKnowledge(searchingValue);
         }


### PR DESCRIPTION
最近タグ名検索を直したので気になって調べました。
#731 について、直接の原因は KnowledgeControl の 401 行目で、タグ名検索またはグループ名検索のときに List を new でインスタンス生成しているため、KnowledgeLogic の
```java
if (groups != null) {
    for (GroupsEntity groupsEntity : groups) {
        searchingValue.addGroup(groupsEntity.getGroupId());
    }
    return searchKnowledge(searchingValue);
}
```
で return してしまっていたためのようです。
KnowledgeControl でグループ名がないときは List インスタンスを生成しないように修正してもいいかと思いましたが、KnowledgeLogic の少し上に
```java
if (tags != null && !tags.isEmpty()) {
    for (TagsEntity tagsEntity : tags) {
        searchingValue.addTag(tagsEntity.getTagId());
    }
}
```
とあったので、IF 条件判定文を直しました。
なお、グループ名検索については問題ないように見えました。