### PR TITLE
fix navbar layout collapse.

### DIFF
--- a/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
+++ b/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
@@ -83,7 +83,7 @@
                 </li>
                 <li class="navButton navListButton">
                     <div class="input-group">
-                        <a href="<%=request.getContextPath()%>/protect.stock/mylist" class="btn btn-secondary" id="navListButtonLink">
+                        <a href="<%=request.getContextPath()%>/protect.stock/mylist" class="btn btn-success" id="navListButtonLink">
                             <i class="fa fa-star-o"></i>&nbsp;<%=jspUtil.label("knowledge.navbar.account.mystock")%>
                         </a>
                     </div>
@@ -92,8 +92,8 @@
                 <% if (!jspUtil.logined()) { %>
                 <li class="navButton navMenuButton">
                     <div class="btn-group">
-                        <a href="#" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" id="navMenuButtonLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <img src="<%= request.getContextPath()%>/open.account/icon/<%= jspUtil.id() %>" alt="icon" width="24" height="24"/>
+                        <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" id="navMenuButtonLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <img src="<%= request.getContextPath()%>/open.account/icon/<%= jspUtil.id() %>" alt="icon" width="15" height="15"/>
                             <span class="caret"></span>
                         </a>
                         <ul class="dropdown-menu" role="menu">
@@ -114,8 +114,8 @@
                 <% } else { %>
                 <li class="navButton navLoginedMenuButton">
                     <div class="btn-group">
-                        <a href="#" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" id="navMenuButtonLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <img src="<%= request.getContextPath()%>/open.account/icon/<%= jspUtil.id() %>" alt="icon" width="24" height="24"/>
+                        <a href="#" class="btn btn-success dropdown-toggle dropdown-toggle-split" id="navMenuButtonLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <img src="<%= request.getContextPath()%>/open.account/icon/<%= jspUtil.id() %>" alt="icon" width="15" height="15"/>
                             <span class="caret"></span>
                         </a>
                         <ul class="dropdown-menu" role="menu">

--- a/src/main/webapp/css/common.css
+++ b/src/main/webapp/css/common.css
@@ -66,38 +66,36 @@ body {
 /*  navbar
 /*--------------------------------- */ 
 .nav .navButton {
-    margin: 5px;
-    height: 50px;
+    margin: 7.5px;
     vertical-align: middle;
     color: white;
 }
 #navAddButtonLink,#navListButtonLink,#navMenuButtonLink {
-    padding-top: 14px;
     color: white;
 }
 .navbar-default .navbar-nav > .navAddButton > a,
 .navbar-default .navbar-nav > .navAddButton > a:hover,
 .navbar-default .navbar-nav > .navAddButton > a:focus {
-    border-radius: 50px;
-    -webkit-border-radius: 50px;
-    -moz-border-radius: 50px;
-    height: 50px;
+    border-radius: 45px;
+    -webkit-border-radius: 45px;
+    -moz-border-radius: 45px;
+    height: 45px;
     background: #009900;
 }
 .navbar-default .navbar-nav > .navListButton > a,
 .navbar-default .navbar-nav > .navListButton > a:hover,
 .navbar-default .navbar-nav > .navListButton > a:focus {
-    border-radius: 50px;
-    -webkit-border-radius: 50px;
-    -moz-border-radius: 50px;
-    height: 50px;
+    border-radius: 45px;
+    -webkit-border-radius: 45px;
+    -moz-border-radius: 45px;
+    height: 45px;
     background: #999900;
 }
 .navbar-nav > .dropdown .dropdown-toggle {
-    border-radius: 50px;
-    -webkit-border-radius: 50px;
-    -moz-border-radius: 50px;
-    height: 50px;
+    border-radius: 45px;
+    -webkit-border-radius: 45px;
+    -moz-border-radius: 45px;
+    height: 45px;
 }
 .navbar-default .navbar-nav > .navMenuButton > a,
 .navbar-default .navbar-nav > .navMenuButton > a:hover,


### PR DESCRIPTION
レスポンシブで横幅が狭くなった時にナビバーがつぶれてしまう問題を少し対処しました。

- ドロップダウンを展開すると子メニューが見えなくなる問題の対処
- ボタンの上下余白が若干サーチバーとずれる部分の修正
- ストックとユーザーメニューに色が付いてなかったのを色をつけるように変更

「スマートフォンで見たときにボタンを押し安くする」ですが私のbootstrapの知識ではいい方法が思いつかず今回はスルーしました、すいません。