### PR TITLE
Fix overlapped style class.

### DIFF
--- a/src/main/webapp/css/slide.css
+++ b/src/main/webapp/css/slide.css
@@ -22,7 +22,7 @@
 }
 @media screen and (min-width: 992px) {
     #content .slideshow-area:-webkit-full-screen,
-    #content .slideshow-area:-moz-full-screen, 
+    #content .slideshow-area:-moz-full-screen,
     #content .slideshow-area:-ms-fullscreen,
     #content .slideshow-area:fullscreen {
         position : fixed ;
@@ -121,20 +121,20 @@
 }
 
 /* Fading animation */
-.fade {
-  -webkit-animation-name: fade;
+.slide-fade {
+  -webkit-animation-name: slide-fade;
   -webkit-animation-duration: 1.5s;
-  animation-name: fade;
+  animation-name: slide-fade;
   animation-duration: 1.5s;
 }
 
-@-webkit-keyframes fade {
-  from {opacity: .4} 
+@-webkit-keyframes slide-fade {
+  from {opacity: .4}
   to {opacity: 1}
 }
 
-@keyframes fade {
-  from {opacity: .4} 
+@keyframes slide-fade {
+  from {opacity: .4}
   to {opacity: 1}
 }
 

--- a/src/main/webapp/css/slide.css
+++ b/src/main/webapp/css/slide.css
@@ -22,7 +22,7 @@
 }
 @media screen and (min-width: 992px) {
     #content .slideshow-area:-webkit-full-screen,
-    #content .slideshow-area:-moz-full-screen,
+    #content .slideshow-area:-moz-full-screen, 
     #content .slideshow-area:-ms-fullscreen,
     #content .slideshow-area:fullscreen {
         position : fixed ;
@@ -129,12 +129,12 @@
 }
 
 @-webkit-keyframes slide-fade {
-  from {opacity: .4}
+  from {opacity: .4} 
   to {opacity: 1}
 }
 
 @keyframes slide-fade {
-  from {opacity: .4}
+  from {opacity: .4} 
   to {opacity: 1}
 }
 

--- a/src/main/webapp/js/slide.js
+++ b/src/main/webapp/js/slide.js
@@ -67,7 +67,7 @@ var showSlide = function(parent) {
                         var slidehtml = '<div class="slideshow-area" id="' + slideId + '">';
                         slidehtml += '<div class="slideshow-container">';
                         for (var i = 0; i < data.files.length; i++) {
-                            slidehtml += '<div class="mySlides fade in">';
+                            slidehtml += '<div class="mySlides slide-fade in">';
                             slidehtml += '<img src="' + _CONTEXT + '/images/loader.gif" lagy="' + _CONTEXT + '/open.file/slide/' + data.fileNo + '/';
                             slidehtml += data.files[i] + '" alt="slide-' + i + '" class="slide-image slide-image-' + fileNo + '" />';
                             slidehtml += '</div>';
@@ -115,10 +115,10 @@ function showSlides(n, slideId) {
     var slideArea = document.getElementById(slideId);
     var slides = slideArea.getElementsByClassName("mySlides");
     var dots = slideArea.getElementsByClassName("dot");
-    if (n > slides.length) {slideIndex = 1} 
+    if (n > slides.length) {slideIndex = 1}
     if (n < 1) {slideIndex = slides.length}
     for (i = 0; i < slides.length; i++) {
-        slides[i].style.display = "none"; 
+        slides[i].style.display = "none";
     }
     for (i = 0; i < dots.length; i++) {
         if (dots[i]) {
@@ -128,11 +128,11 @@ function showSlides(n, slideId) {
     slides[slideIndex-1].style.display = "block";
     var slideimg = $(slides[slideIndex-1].getElementsByTagName('img')[0]);
     slideimg.attr('src', slideimg.attr('lagy'));
-    
+
     if (dots[slideIndex-1]) {
         dots[slideIndex-1].className += " active";
     }
-    
+
     $('#' + slideId).find('.current').html(slideIndex);
     indexMap[slideId] = slideIndex;
 }

--- a/src/main/webapp/js/slide.js
+++ b/src/main/webapp/js/slide.js
@@ -115,10 +115,10 @@ function showSlides(n, slideId) {
     var slideArea = document.getElementById(slideId);
     var slides = slideArea.getElementsByClassName("mySlides");
     var dots = slideArea.getElementsByClassName("dot");
-    if (n > slides.length) {slideIndex = 1}
+    if (n > slides.length) {slideIndex = 1} 
     if (n < 1) {slideIndex = slides.length}
     for (i = 0; i < slides.length; i++) {
-        slides[i].style.display = "none";
+        slides[i].style.display = "none"; 
     }
     for (i = 0; i < dots.length; i++) {
         if (dots[i]) {
@@ -128,11 +128,11 @@ function showSlides(n, slideId) {
     slides[slideIndex-1].style.display = "block";
     var slideimg = $(slides[slideIndex-1].getElementsByTagName('img')[0]);
     slideimg.attr('src', slideimg.attr('lagy'));
-
+    
     if (dots[slideIndex-1]) {
         dots[slideIndex-1].className += " active";
     }
-
+    
     $('#' + slideId).find('.current').html(slideIndex);
     indexMap[slideId] = slideIndex;
 }


### PR DESCRIPTION
#725 に関連して、fade クラスが bootstrap と slide.css で重複していたので修正しました。
slide.css の fade は slide.js 以外では使用していない認識ですが、修正不足があればお知らせください。