### PR TITLE
Fix when modal dialog open, navbar slides slightly.

### DIFF
--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -25,6 +25,27 @@ $(document).ready(function() {
         }
     });
     
+    $(document).ready(function(){
+        $(window).load(function(){
+            var oldSSB = $.fn.modal.Constructor.prototype.setScrollbar;
+            $.fn.modal.Constructor.prototype.setScrollbar = function () 
+            {
+                oldSSB.apply(this);
+                if(this.bodyIsOverflowing && this.scrollbarWidth) 
+                {
+                    $('.navbar-fixed-top, .navbar-fixed-bottom').css('padding-right', this.scrollbarWidth);
+                }
+            }
+
+            var oldRSB = $.fn.modal.Constructor.prototype.resetScrollbar;
+            $.fn.modal.Constructor.prototype.resetScrollbar = function () 
+            {
+                oldRSB.apply(this);
+                $('.navbar-fixed-top, .navbar-fixed-bottom').css('padding-right', '');
+            }
+        });
+    });
+    
     // セッションが切れないように、定期的にアクセスする(5分に1回)
     var accessInterval = function() {
         setInterval(function() {

--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -25,25 +25,23 @@ $(document).ready(function() {
         }
     });
     
-    $(document).ready(function(){
-        $(window).load(function(){
-            var oldSSB = $.fn.modal.Constructor.prototype.setScrollbar;
-            $.fn.modal.Constructor.prototype.setScrollbar = function () 
+    $(window).load(function(){
+        var oldSSB = $.fn.modal.Constructor.prototype.setScrollbar;
+        $.fn.modal.Constructor.prototype.setScrollbar = function () 
+        {
+            oldSSB.apply(this);
+            if(this.bodyIsOverflowing && this.scrollbarWidth) 
             {
-                oldSSB.apply(this);
-                if(this.bodyIsOverflowing && this.scrollbarWidth) 
-                {
-                    $('.navbar-fixed-top, .navbar-fixed-bottom').css('padding-right', this.scrollbarWidth);
-                }
+                $('.navbar-fixed-top, .navbar-fixed-bottom').css('padding-right', this.scrollbarWidth);
             }
+        }
 
-            var oldRSB = $.fn.modal.Constructor.prototype.resetScrollbar;
-            $.fn.modal.Constructor.prototype.resetScrollbar = function () 
-            {
-                oldRSB.apply(this);
-                $('.navbar-fixed-top, .navbar-fixed-bottom').css('padding-right', '');
-            }
-        });
+        var oldRSB = $.fn.modal.Constructor.prototype.resetScrollbar;
+        $.fn.modal.Constructor.prototype.resetScrollbar = function () 
+        {
+            oldRSB.apply(this);
+            $('.navbar-fixed-top, .navbar-fixed-bottom').css('padding-right', '');
+        }
     });
     
     // セッションが切れないように、定期的にアクセスする(5分に1回)


### PR DESCRIPTION
ストックボタンをクリックすると、ダイアログが出ている間だけスクロールバーが消えて、ナビゲーションバーがずれるのが前から気になっていて調べました（他のダイアログも同様）。

https://github.com/twbs/bootstrap/issues/14040

がこの事象と一致すると思うのですが、Bootstrap 3 系はもう修正しないようなので、このページに載っていたワークアラウンドで対処しました。

主要なブラウザの最新版では動作確認済みです。

Bootstrap jQuery Modal を拡張しているコードなので他に影響はないのではないかと考えています。