### PR TITLE
fix drop target of images.

### DIFF
--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -61,6 +61,13 @@ $(document).ready(function() {
     };
     accessInterval();
 });
+
+// ファイルをドロップしたときのブラウザデフォルトの動作を抑止する。
+$(document).on('drop dragover', function (e) {
+    e.stopPropagation();
+    e.preventDefault();
+});
+
 function logging(str, level) {
 //    console.log(str);
     if (_LOGGING_NOTIFY_DESKTOP) {

--- a/src/main/webapp/js/knowledge-attachfile.js
+++ b/src/main/webapp/js/knowledge-attachfile.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
         dataType : 'json',
         autoUpload: true,
         maxFileSize: 5000000, // 5 MB
+        dropZone: '#drop_target',
     }).on('fileuploaddone', function (e, data) {
         //$('#files').show();
         uploadedFiles(data.result.files);

--- a/src/main/webapp/js/knowledge-view-attachfile.js
+++ b/src/main/webapp/js/knowledge-view-attachfile.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
         dataType : 'json',
         autoUpload: true,
         maxFileSize: 5000000, // 5 MB
+        dropZone: '#drop_target',
     }).on('fileuploaddone', function (e, data) {
         uploadedFiles(data.result.files);
         setTimeout(function() {
@@ -47,7 +48,6 @@ $(document).ready(function() {
     });
     
 });
-
 
 var uploadedFiles = function(files) {
     console.log(files);


### PR DESCRIPTION
#810 に対してパッチを書きました。
この動作を確認いただいて、何か気になる点があれば再修正していきたい考えです。

* ブラウザ全体が画像のドロップターゲットでしたが、それを指定されたエリアだけに変更しました。
* 上記修正により、指定エリア以外に画像をドロップすると、ブラウザのデフォルトの挙動でローカルの画像ファイルが開くようになってしまったので、その挙動を抑止しました。

IE11/Edge/Firefox/Chrome/Safari （すべて現在の最新版）で動作確認済みです。