### PR TITLE
Fix when Add dropdown is clicked, Add button becomes hard to see.

### DIFF
--- a/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
+++ b/src/main/webapp/WEB-INF/views/commons/layout/commonNavbar.jsp
@@ -67,10 +67,10 @@
             <ul class="nav navbar-nav navbar-right">
                 <li class="navButton navAddButton">
                     <div class="btn-group">
-                        <a href="<%= request.getContextPath() %>/protect.knowledge/view_add<%= jspUtil.out("params") %>" class="btn btn-info" id="navAddButtonLink">
+                        <button type="button" onclick="location.href='<%= request.getContextPath() %>/protect.knowledge/view_add<%= jspUtil.out("params") %>'" class="btn btn-info" id="navAddButtonLink" tabindex="-1">
                             <i class="fa fa-plus-circle"></i>&nbsp;
                             <span class="navListButtonText"><%= jspUtil.label("knowledge.navbar.add.knowledge") %></span>
-                        </a>
+                        </button>
                         <a href="#" class="btn btn-info dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <span class="caret"></span>
                         </a>

--- a/src/main/webapp/js/slide.js
+++ b/src/main/webapp/js/slide.js
@@ -140,7 +140,7 @@ function showSlides(n, slideId) {
 $(document).on({
 	'mouseenter': function () {
 		var id = $(this).attr('id');
-		$(window).on('keypress', function (e) {
+		$(window).on('keydown', function (e) {
 			e.preventDefault();
 
 			if (37 == e.keyCode) {
@@ -153,6 +153,6 @@ $(document).on({
 		});
 	},
 	'mouseleave': function () {
-		$(window).off('keypress');
+		$(window).off('keydown');
 	}
 }, '.slideshow-area');


### PR DESCRIPTION
ヘッダーの作成ボタンのドロップダウンをクリックしたとき、隣のボタンの背景色が白っぽくなって見づらくなっていたのが気になっていたので、色が変わらないように修正しました。

![add-button](https://user-images.githubusercontent.com/9009605/30731384-09bc4884-9fa8-11e7-823f-9f2ebcf901bb.png)

![add-button-after](https://user-images.githubusercontent.com/9009605/30731641-8d287660-9fa9-11e7-9766-a8bea58d8925.png)

## 修正内容について

HTML 上で nav クラスの子孫に a タグがあると、bootstrap.css の

```css
.nav .open > a,
.nav .open > a:hover,
.nav .open > a:focus {
  background-color: （テーマによって異なる）
  border-color: （テーマによって異なる）
}
```

の部分がドロップダウンをクリックしたときに有効化されてしまって、その結果、背景色が変わるようでした。ここを common.css 等で上書きしても全テーマで同じ背景色になってしまうため、PR のように a タグを button タグに変更する方法を採用しました。

その際、tabindex を無効化しています。Tab キーを押したときの遷移はOS/ブラウザによって挙動が異なるようでしたのでどうするべきか迷いましたが、作成ボタンとドロップダウン２つで１つかと思い、ドロップダウンのみ Tab キーで遷移するようにしています。