### PR TITLE
Fix keypress events does not fired on pushing arrow keys.

### DIFF
--- a/src/main/webapp/js/slide.js
+++ b/src/main/webapp/js/slide.js
@@ -140,7 +140,7 @@ function showSlides(n, slideId) {
 $(document).on({
 	'mouseenter': function () {
 		var id = $(this).attr('id');
-		$(window).on('keypress', function (e) {
+		$(window).on('keydown', function (e) {
 			e.preventDefault();
 
 			if (37 == e.keyCode) {
@@ -153,6 +153,6 @@ $(document).on({
 		});
 	},
 	'mouseleave': function () {
-		$(window).off('keypress');
+		$(window).off('keydown');
 	}
 }, '.slideshow-area');


### PR DESCRIPTION
#860 に関して、矢印キーを押したときは keypress イベントが Firefox 以外では起動しなかったことが原因のようです。