### PR TITLE
Fix the problem where don't work JavaScript when delete a user on English mode

### DIFF
--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -362,7 +362,7 @@ knowledge.account.info.ldap=This user is Ldap user. so you can update role only.
 knowledge.account.info.ldap2=You are Ldap user. so you can update role only.
 knowledge.account.targets=Default Targets
 knowledge.account.targets.select=Choose your default viewer target.
-knowledge.account.delete.confirm=Are you sure you want to delete?<br/>And this account's knowldge will delete?
+knowledge.account.delete.confirm=Are you sure you want to delete?<br/>And this account&apos;s knowldge will delete?<br/>
 knowledge.account.delete.knowledge.keep=Keep
 knowledge.account.delete.knowledge.remove=Remove All
 


### PR DESCRIPTION
# 英語モードでユーザを削除することが出来ない

英語リソースのアポストロフィが原因でJavaScriptが解釈されないため

![before](https://user-images.githubusercontent.com/3918654/31316253-e98243ec-ac64-11e7-9840-35bc608e5ba1.png)

文字参照に置き換え、改行タグ追加

![after](https://user-images.githubusercontent.com/3918654/31316230-78dab0f2-ac64-11e7-85c1-17fb35d0dc7a.png)
