### PR TITLE
Improve jump position from table of contents

### DIFF
--- a/src/main/webapp/js/knowledge-view-toc.js
+++ b/src/main/webapp/js/knowledge-view-toc.js
@@ -2,6 +2,7 @@ var shownAgenda = false;
 var agenda;
 var createAgenda = function() {
     console.log('createAgenda');
+    var navbarHeight = $('nav.navbar-fixed-top').outerHeight(true);
     var toc = $('#toc');
     var exists = false;
     $('.markdown h1, .markdown h2, .markdown h3').each(function() {
@@ -17,7 +18,7 @@ var createAgenda = function() {
 
         $a.click(function() {
             $('body, html').animate({
-                scrollTop : $('#' + targetId).offset().top
+                scrollTop : $('#' + targetId).offset().top - navbarHeight
             }, 500);
             return false;
         });


### PR DESCRIPTION
When click the table of contents,  title hides behind navbar.

ex. select タイトル2.

before
![before](https://user-images.githubusercontent.com/3918654/31846743-e316c92a-b64a-11e7-8d63-738d85d77ac0.png)

after
![after](https://user-images.githubusercontent.com/3918654/31846745-e4664b66-b64a-11e7-8a65-87b9476e5c1c.png)
