### PR TITLE
Fixed that the footer floats when it is few content.

### DIFF
--- a/src/main/webapp/css/common.css
+++ b/src/main/webapp/css/common.css
@@ -6,9 +6,12 @@ body {
 /    Footer
 /* ------------------------------------- */
 #footer {
+    position: fixed;
     text-align: center;
     padding: 20px 0;
     margin-top: 60px;
+    bottom: 0;
+    width: 100%;
     background-color: #7E7E7E;
     color: #cccccc;
 }


### PR DESCRIPTION
ありがたく利用させていただいております。

ページ内容が少ない場合にフッターが浮いていたのを修正しました。よろしければご確認ください。

Before:
![before](https://i.gyazo.com/6c4ed64527da0eacfcc02bb63a67d303.png)

After:
![after](https://i.gyazo.com/e5f2bf322b1c28936e70e3d3765dc793.png)