### PR TITLE
Add disp/hide feature of pagination buttons

### DIFF
--- a/src/main/java/org/support/project/knowledge/bat/CreateExportDataBat.java
+++ b/src/main/java/org/support/project/knowledge/bat/CreateExportDataBat.java
@@ -25,6 +25,7 @@ import org.support.project.knowledge.entity.KnowledgesEntity;
 import org.support.project.knowledge.logic.CompressLogic;
 import org.support.project.knowledge.logic.KnowledgeLogic;
 import org.support.project.knowledge.vo.ExportUser;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.web.bean.LoginedUser;
 import org.support.project.web.dao.SystemConfigsDao;
 import org.support.project.web.dao.UsersDao;
@@ -82,7 +83,8 @@ public class CreateExportDataBat extends AbstractBat {
         CommentsDao commentsDao = CommentsDao.get();
         KnowledgeFilesDao knowledgeFilesDao = KnowledgeFilesDao.get();
 
-        List<KnowledgesEntity> knowledges = knowledgeLogic.searchKnowledge("", loginedUser, 0, 100);
+        KnowledgeListInfo knowledgesListInfo = knowledgeLogic.searchKnowledge("", loginedUser, 0, 100);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         for (KnowledgesEntity knowledgesEntity : knowledges) {
             File f = new File(dir, "knowledge-" + StringUtils.zeroPadding(knowledgesEntity.getKnowledgeId(), 6) + ".xml");
             String xml = SerializeUtils.objectToXml(knowledgesEntity);

--- a/src/main/java/org/support/project/knowledge/control/open/AccountControl.java
+++ b/src/main/java/org/support/project/knowledge/control/open/AccountControl.java
@@ -28,6 +28,7 @@ import org.support.project.knowledge.logic.activity.ActivityLogic;
 import org.support.project.knowledge.vo.AccountInfo;
 import org.support.project.knowledge.vo.ActivityHistory;
 import org.support.project.knowledge.vo.ContributionPointHistory;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.knowledge.vo.StockKnowledge;
 import org.support.project.web.boundary.Boundary;
 import org.support.project.web.control.service.Get;
@@ -97,7 +98,8 @@ public class AccountControl extends Control {
         if (StringUtils.isInteger(getParam("offset"))) {
             offset = getParam("offset", Integer.class);
         }
-        List<KnowledgesEntity> knowledges = KnowledgeLogic.get().showKnowledgeOnUser(userId, getLoginedUser(), offset * PAGE_LIMIT, PAGE_LIMIT);
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().showKnowledgeOnUser(userId, getLoginedUser(), offset * PAGE_LIMIT, PAGE_LIMIT);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         List<StockKnowledge> stocks = KnowledgeLogic.get().setStockInfo(knowledges, getLoginedUser());
         KnowledgeLogic.get().setViewed(stocks, getLoginedUser());
         setAttribute("knowledges", stocks);
@@ -147,7 +149,8 @@ public class AccountControl extends Control {
         if (StringUtils.isInteger(getParam("offset"))) {
             offset = getParam("offset", Integer.class);
         }
-        List<KnowledgesEntity> knowledges = KnowledgeLogic.get().showKnowledgeOnUser(userId, getLoginedUser(), offset * PAGE_LIMIT, PAGE_LIMIT);
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().showKnowledgeOnUser(userId, getLoginedUser(), offset * PAGE_LIMIT, PAGE_LIMIT);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         List<StockKnowledge> stocks = KnowledgeLogic.get().setStockInfo(knowledges, getLoginedUser());
         KnowledgeLogic.get().setViewed(stocks, getLoginedUser());
         return send(stocks);

--- a/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
@@ -586,7 +586,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
             setAttribute("totalCount", totalCount);
             setAttribute("pinnedCount", pinnedCount);
             setAttribute("currentPageStart", offset * PAGE_LIMIT + 1);
-                       if (totalCount < (offset + 1) * PAGE_LIMIT) {
+            if (totalCount < (offset + 1) * PAGE_LIMIT) {
                 setAttribute("currentPageEnd", totalCount);
             } else {
                 setAttribute("currentPageEnd", (offset + 1) * PAGE_LIMIT);

--- a/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
@@ -60,6 +60,7 @@ import org.support.project.knowledge.logic.TimeZoneLogic;
 import org.support.project.knowledge.logic.UploadedFileLogic;
 import org.support.project.knowledge.logic.activity.Activity;
 import org.support.project.knowledge.logic.activity.ActivityLogic;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.knowledge.vo.LikeCount;
 import org.support.project.knowledge.vo.ListData;
 import org.support.project.knowledge.vo.MarkDown;
@@ -406,12 +407,15 @@ public class KnowledgeControl extends KnowledgeControlBase {
         knowledgeLogic.setKeywordSortType(keywordSortType);
         setAttribute("keywordSortType", keywordSortType);
 
+        int totalCount = 0;
         List<KnowledgesEntity> knowledges = new ArrayList<>();
         try {
             if (StringUtils.isInteger(tag)) {
                 // タグを選択している
                 LOG.trace("show on Tag");
-                knowledges.addAll(knowledgeLogic.showKnowledgeOnTag(tag, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT));
+                KnowledgeListInfo knowledgesListInfo = knowledgeLogic.showKnowledgeOnTag(tag, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT);
+                knowledges.addAll(knowledgesListInfo.getKnowledgesEntityList());
+                totalCount = knowledgesListInfo.getSearchResultTotalCount();
                 TagsEntity tagsEntity = tagsDao.selectOnKey(new Integer(tag));
                 List<Integer> tagIds = new ArrayList<Integer>();
                 String name = "";
@@ -425,7 +429,9 @@ public class KnowledgeControl extends KnowledgeControlBase {
             } else if (StringUtils.isInteger(group)) {
                 // グループを選択している
                 LOG.trace("show on Group");
-                knowledges.addAll(knowledgeLogic.showKnowledgeOnGroup(group, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT));
+                KnowledgeListInfo knowledgesListInfo = knowledgeLogic.showKnowledgeOnGroup(group, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT);
+                knowledges.addAll(knowledgesListInfo.getKnowledgesEntityList());
+                totalCount = knowledgesListInfo.getSearchResultTotalCount();
                 GroupsEntity groupsEntity = groupsDao.selectOnKey(new Integer(group));
                 List<Integer> groupIds = new ArrayList<Integer>();
                 String name = "";
@@ -440,7 +446,9 @@ public class KnowledgeControl extends KnowledgeControlBase {
                 // ユーザを選択している
                 LOG.trace("show on User");
                 int userId = Integer.parseInt(user);
-                knowledges.addAll(knowledgeLogic.showKnowledgeOnUser(userId, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT));
+                KnowledgeListInfo knowledgesListInfo = knowledgeLogic.showKnowledgeOnUser(userId, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT);
+                knowledges.addAll(knowledgesListInfo.getKnowledgesEntityList());
+                totalCount = knowledgesListInfo.getSearchResultTotalCount();
                 UsersEntity usersEntity = UsersDao.get().selectOnKey(userId);
                 usersEntity.setPassword("");
                 setAttribute("selectedUser", usersEntity);
@@ -492,7 +500,9 @@ public class KnowledgeControl extends KnowledgeControlBase {
                 setAttribute("selectedGroupIds", groupIds);
                 setAttribute("searchKeyword", searchKeyword + keyword);
     
-                knowledges.addAll(knowledgeLogic.searchKnowledge(keyword, tags, groups, null, templates, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT));
+                KnowledgeListInfo knowledgesListInfo = knowledgeLogic.searchKnowledge(keyword, tags, groups, null, templates, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT);
+                knowledges.addAll(knowledgesListInfo.getKnowledgesEntityList());
+                totalCount = knowledgesListInfo.getSearchResultTotalCount();
             } else {
                 // その他(キーワード検索)
                 LOG.trace("search");
@@ -545,7 +555,9 @@ public class KnowledgeControl extends KnowledgeControlBase {
                 }
                 setAttribute("creators", creatorUserEntities);
                 
-                knowledges.addAll(knowledgeLogic.searchKnowledge(keyword, tags, groups, creatorUserEntities, templates, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT));
+                KnowledgeListInfo knowledgesListInfo = knowledgeLogic.searchKnowledge(keyword, tags, groups, creatorUserEntities, templates, loginedUser, offset * PAGE_LIMIT, PAGE_LIMIT);
+                knowledges.addAll(knowledgesListInfo.getKnowledgesEntityList());
+                totalCount = knowledgesListInfo.getSearchResultTotalCount();
             }
             
             // pin留めの記事取得
@@ -565,6 +577,16 @@ public class KnowledgeControl extends KnowledgeControlBase {
                         knowledges.add(0, k); // 先頭に追加
                     }
                 }
+            }
+            
+            // ページングに関する情報設定
+            setAttribute("hasNextPage", totalCount > (offset + 1) * PAGE_LIMIT);
+            setAttribute("totalCount", totalCount);
+            setAttribute("currentPageStart", offset * PAGE_LIMIT + 1);
+            if (totalCount < (offset + 1) * PAGE_LIMIT) {
+                setAttribute("currentPageEnd", totalCount);
+            } else {
+                setAttribute("currentPageEnd", (offset + 1) * PAGE_LIMIT);
             }
     
             List<StockKnowledge> stocks = knowledgeLogic.setStockInfo(knowledges, loginedUser);

--- a/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
+++ b/src/main/java/org/support/project/knowledge/control/open/KnowledgeControl.java
@@ -561,6 +561,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
             }
             
             // pin留めの記事取得
+            int pinnedCount = 0;
             if (0 == offset.intValue()) {
                 List<PinsEntity> pins = PinsDao.get().selectAll();
                 for (PinsEntity pin : pins) {
@@ -574,6 +575,7 @@ public class KnowledgeControl extends KnowledgeControlBase {
                             }
                         }
                         k.setPin(true);
+                        pinnedCount++;
                         knowledges.add(0, k); // 先頭に追加
                     }
                 }
@@ -582,8 +584,9 @@ public class KnowledgeControl extends KnowledgeControlBase {
             // ページングに関する情報設定
             setAttribute("hasNextPage", totalCount > (offset + 1) * PAGE_LIMIT);
             setAttribute("totalCount", totalCount);
+            setAttribute("pinnedCount", pinnedCount);
             setAttribute("currentPageStart", offset * PAGE_LIMIT + 1);
-            if (totalCount < (offset + 1) * PAGE_LIMIT) {
+                       if (totalCount < (offset + 1) * PAGE_LIMIT) {
                 setAttribute("currentPageEnd", totalCount);
             } else {
                 setAttribute("currentPageEnd", (offset + 1) * PAGE_LIMIT);

--- a/src/main/java/org/support/project/knowledge/logic/IndexLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/IndexLogic.java
@@ -1,7 +1,5 @@
 package org.support.project.knowledge.logic;
 
-import java.util.List;
-
 import org.support.project.common.log.Log;
 import org.support.project.common.log.LogFactory;
 import org.support.project.di.Container;
@@ -9,7 +7,7 @@ import org.support.project.di.DI;
 import org.support.project.di.Instance;
 import org.support.project.knowledge.indexer.Indexer;
 import org.support.project.knowledge.indexer.IndexingValue;
-import org.support.project.knowledge.searcher.SearchResultValue;
+import org.support.project.knowledge.searcher.SearchResultAggregate;
 import org.support.project.knowledge.searcher.Searcher;
 import org.support.project.knowledge.searcher.SearchingValue;
 
@@ -48,13 +46,13 @@ public class IndexLogic {
      * @return
      * @throws Exception
      */
-    public List<SearchResultValue> search(SearchingValue search, int keywordSortType) throws Exception {
+    public SearchResultAggregate search(SearchingValue search, int keywordSortType) throws Exception {
         Searcher searcher = Container.getComp(Searcher.class);
-        List<SearchResultValue> list = searcher.search(search, keywordSortType);
+        SearchResultAggregate result = searcher.search(search, keywordSortType);
         if (LOG.isDebugEnabled()) {
-            LOG.debug(JSON.encode(list, true));
+            LOG.debug(JSON.encode(result, true));
         }
-        return list;
+        return result;
     }
 
     /**

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeDataSelectLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeDataSelectLogic.java
@@ -23,6 +23,7 @@ import org.support.project.knowledge.entity.KnowledgeItemValuesEntity;
 import org.support.project.knowledge.entity.KnowledgesEntity;
 import org.support.project.knowledge.entity.TemplateItemsEntity;
 import org.support.project.knowledge.entity.TemplateMastersEntity;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.knowledge.vo.SearchKnowledgeParam;
 import org.support.project.knowledge.vo.api.AttachedFile;
 import org.support.project.knowledge.vo.api.Comment;
@@ -244,7 +245,7 @@ public class KnowledgeDataSelectLogic {
         String [] templates = {param.getTemplate()}; // TODO テンプレートの複数指定に対応させる
 
         List<Knowledge> results = new ArrayList<>();
-        List<KnowledgesEntity> entities = KnowledgeLogic.get().searchKnowledge(
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(
                 param.getKeyword(),
                 param.getTags(),
                 param.getGroups(),
@@ -253,6 +254,7 @@ public class KnowledgeDataSelectLogic {
                 param.getLoginedUser(),
                 param.getOffset(),
                 param.getLimit());
+        List<KnowledgesEntity> entities = knowledgesListInfo.getKnowledgesEntityList();
         List<String> ids = new ArrayList<>();
         for (KnowledgesEntity entity : entities) {
             Knowledge result = conv(entity, LIST);

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -63,9 +63,11 @@ import org.support.project.knowledge.logic.activity.ActivityLogic;
 import org.support.project.knowledge.logic.hook.AfterSaveHook;
 import org.support.project.knowledge.logic.hook.BeforeSaveHook;
 import org.support.project.knowledge.logic.hook.HookFactory;
+import org.support.project.knowledge.searcher.SearchResultAggregate;
 import org.support.project.knowledge.searcher.SearchResultValue;
 import org.support.project.knowledge.searcher.SearchingValue;
 import org.support.project.knowledge.vo.KnowledgeData;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.knowledge.vo.StockKnowledge;
 import org.support.project.web.bean.LabelValue;
 import org.support.project.web.bean.LoginedUser;
@@ -514,17 +516,17 @@ public class KnowledgeLogic {
      * @return
      * @throws Exception
      */
-    private List<KnowledgesEntity> searchKnowledge(SearchingValue searchingValue) throws Exception {
+    private KnowledgeListInfo searchKnowledge(SearchingValue searchingValue) throws Exception {
         if (LOG.isDebugEnabled()) {
             LOG.debug("search params：" + PropertyUtil.reflectionToString(searchingValue));
         }
         LOG.trace("検索開始");
-        List<SearchResultValue> list = IndexLogic.get().search(searchingValue, this.keywordSortType);
+        SearchResultAggregate results = IndexLogic.get().search(searchingValue, this.keywordSortType);
         LOG.trace("検索終了");
         LOG.trace("付加情報をセット開始");
-        List<KnowledgesEntity> result = getKnowledgeDatas(list);
+        List<KnowledgesEntity> result = getKnowledgeDatas(results.getResultList());
         LOG.trace("付加情報をセット終了");
-        return result;
+        return new KnowledgeListInfo(results.getTotalResultCount(), result);
     }
 
     /**
@@ -540,7 +542,7 @@ public class KnowledgeLogic {
      * @return
      * @throws Exception
      */
-    public List<KnowledgesEntity> searchKnowledge(String keyword, List<TagsEntity> tags, List<GroupsEntity> groups, 
+    public KnowledgeListInfo searchKnowledge(String keyword, List<TagsEntity> tags, List<GroupsEntity> groups, 
             List<UsersEntity> creators, String[] templates, LoginedUser loginedUser,
             Integer offset, Integer limit) throws Exception {
         SearchingValue searchingValue = new SearchingValue();
@@ -624,7 +626,7 @@ public class KnowledgeLogic {
      * @return
      * @throws Exception
      */
-    public List<KnowledgesEntity> searchKnowledge(String keyword, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
+    public KnowledgeListInfo searchKnowledge(String keyword, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
         return searchKnowledge(keyword, null, null, null, null, loginedUser, offset, limit);
     }
 
@@ -638,7 +640,7 @@ public class KnowledgeLogic {
      * @return
      * @throws Exception
      */
-    public List<KnowledgesEntity> showKnowledgeOnTag(String tag, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
+    public KnowledgeListInfo showKnowledgeOnTag(String tag, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.setOffset(offset);
         searchingValue.setLimit(limit);
@@ -678,10 +680,10 @@ public class KnowledgeLogic {
      * @return
      * @throws Exception
      */
-    public List<KnowledgesEntity> showKnowledgeOnGroup(String group, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
+    public KnowledgeListInfo showKnowledgeOnGroup(String group, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
         List<KnowledgesEntity> knowledges = new ArrayList<KnowledgesEntity>();
         if (loginedUser == null) {
-            return knowledges;
+            return new KnowledgeListInfo(0, knowledges);
         }
 
         SearchingValue searchingValue = new SearchingValue();
@@ -703,7 +705,7 @@ public class KnowledgeLogic {
             }
         }
 
-        return knowledges;
+        return new KnowledgeListInfo(0, knowledges);
     }
 
     /**
@@ -715,7 +717,7 @@ public class KnowledgeLogic {
      * @return
      * @throws Exception
      */
-    public List<KnowledgesEntity> showKnowledgeOnUser(int targetUser, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
+    public KnowledgeListInfo showKnowledgeOnUser(int targetUser, LoginedUser loginedUser, Integer offset, Integer limit) throws Exception {
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.setOffset(offset);
         searchingValue.setLimit(limit);

--- a/src/main/java/org/support/project/knowledge/searcher/SearchResultAggregate.java
+++ b/src/main/java/org/support/project/knowledge/searcher/SearchResultAggregate.java
@@ -1,0 +1,38 @@
+package org.support.project.knowledge.searcher;
+
+import java.util.List;
+
+public class SearchResultAggregate {
+
+    /** 検索結果の総件数 */
+    private int totalResultCount;
+    
+    /** 検索条件に一致した Lucene 検索結果のリスト */
+    private List<SearchResultValue> resultList;
+    
+    /**
+     * コンストラクタ
+     * @param totalResultCount 検索結果の総件数
+     * @param resultList 検索条件に一致した Lucene 検索結果のリスト
+     */
+    public SearchResultAggregate(int totalResultCount, List<SearchResultValue> resultList) {
+        this.totalResultCount = totalResultCount;
+        this.resultList = resultList;
+    }
+
+    /**
+     * 検索結果の総件数を取得します。
+     * @return 検索結果の総件数
+     */
+    public int getTotalResultCount() {
+        return this.totalResultCount;
+    }
+    
+    /**
+     * 検索条件に一致した Lucene 検索結果のリストを取得します。
+     * @return 検索条件に一致した Lucene 検索結果のリスト
+     */
+    public List<SearchResultValue> getResultList() {
+        return this.resultList;
+    }
+}

--- a/src/main/java/org/support/project/knowledge/searcher/Searcher.java
+++ b/src/main/java/org/support/project/knowledge/searcher/Searcher.java
@@ -1,7 +1,5 @@
 package org.support.project.knowledge.searcher;
 
-import java.util.List;
-
 import org.support.project.di.DI;
 import org.support.project.knowledge.searcher.impl.LuceneSearcher;
 
@@ -16,6 +14,6 @@ public interface Searcher {
      * @return
      * @throws Exception
      */
-    List<SearchResultValue> search(SearchingValue value, int keywordSortType) throws Exception;
+    SearchResultAggregate search(SearchingValue value, int keywordSortType) throws Exception;
 
 }

--- a/src/main/java/org/support/project/knowledge/searcher/impl/LuceneSearcher.java
+++ b/src/main/java/org/support/project/knowledge/searcher/impl/LuceneSearcher.java
@@ -42,6 +42,7 @@ import org.support.project.knowledge.config.AppConfig;
 import org.support.project.knowledge.config.IndexType;
 import org.support.project.knowledge.indexer.impl.LuceneIndexer;
 import org.support.project.knowledge.logic.KnowledgeLogic;
+import org.support.project.knowledge.searcher.SearchResultAggregate;
 import org.support.project.knowledge.searcher.SearchResultValue;
 import org.support.project.knowledge.searcher.Searcher;
 import org.support.project.knowledge.searcher.SearchingValue;
@@ -102,16 +103,16 @@ public class LuceneSearcher implements Searcher {
      * 検索
      * @throws InvalidParamException 
      */
-    public List<SearchResultValue> search(final SearchingValue value, int keywordSortType) throws IOException, InvalidTokenOffsetsException, InvalidParamException {
+    public SearchResultAggregate search(final SearchingValue value, int keywordSortType) throws IOException, InvalidTokenOffsetsException, InvalidParamException {
         List<SearchResultValue> resultValues = new ArrayList<>();
 
         File indexDir = new File(getIndexPath());
         if (!indexDir.exists()) {
-            return resultValues;
+            return new SearchResultAggregate(0, resultValues);
         }
         File[] children = indexDir.listFiles();
         if (children == null || children.length == 0) {
-            return resultValues;
+            return new SearchResultAggregate(0, resultValues);
         }
 
         IndexReader reader = DirectoryReader.open(FSDirectory.open(indexDir));
@@ -192,7 +193,7 @@ public class LuceneSearcher implements Searcher {
             resultValues.add(resultValue);
         }
 
-        return resultValues;
+        return new SearchResultAggregate(countCollector.getTotalHits(), resultValues);
 
     }
 

--- a/src/main/java/org/support/project/knowledge/vo/KnowledgeListInfo.java
+++ b/src/main/java/org/support/project/knowledge/vo/KnowledgeListInfo.java
@@ -1,0 +1,27 @@
+package org.support.project.knowledge.vo;
+
+import java.util.List;
+
+import org.support.project.knowledge.entity.KnowledgesEntity;
+
+public class KnowledgeListInfo {
+
+    /** ナレッジの検索結果総件数（Lucene ベース） */
+    private int searchResultTotalCount;
+    
+    /** ナレッジのリスト */
+    private List<KnowledgesEntity> knowledgesEntityList;
+    
+    public KnowledgeListInfo(int searchResultTotalCount, List<KnowledgesEntity> knowledgesEntityList) {
+        this.searchResultTotalCount = searchResultTotalCount;
+        this.knowledgesEntityList = knowledgesEntityList;
+    }
+    
+    public int getSearchResultTotalCount() {
+        return this.searchResultTotalCount;
+    }
+    
+    public List<KnowledgesEntity> getKnowledgesEntityList() {
+        return this.knowledgesEntityList;
+    }
+}

--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -239,6 +239,8 @@ knowledge.list.sort.time=Update time
 knowledge.list.events=Event
 knowledge.list.event.start=Events from {1}
 knowledge.list.event.datetime=DateTime
+knowledge.list.pagination.current= {1} - {2} of {3}
+knowledge.list.pagination.pinned= (plus {1} pinned knowledge(s))
 
 knowledge.view.title=Show Knowledge
 knowledge.view.like=Like!

--- a/src/main/resources/appresource_ja.properties
+++ b/src/main/resources/appresource_ja.properties
@@ -239,6 +239,8 @@ knowledge.list.sort.time=更新順
 knowledge.list.events=イベント
 knowledge.list.event.start={1} 以降のイベント
 knowledge.list.event.datetime=開始日時
+knowledge.list.pagination.current=全 {1} 件中、{2} 件目 〜 {3} 件目を表示中
+knowledge.list.pagination.pinned=（ピン留め中のナレッジを {1} 件表示中）
 
 knowledge.view.title=ナレッジ表示
 knowledge.view.like=いいね！

--- a/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
@@ -254,6 +254,13 @@
             %>
             <p>
                 全 <%= jspUtil.attr("totalCount") %> 件中、<%= jspUtil.attr("currentPageStart") %> 件目 〜 <%= jspUtil.attr("currentPageEnd") %> 件目を表示中
+                <%
+                    if (!jspUtil.attr("pinnedCount").equals("0")) {
+                %>
+                （ピン留め記事を <%= jspUtil.attr("pinnedCount") %> 件表示中）
+                <%
+                    }
+                %>
             </p>
             <%
                 }

--- a/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
@@ -253,11 +253,11 @@
                 if (!jspUtil.attr("totalCount").equals("0")) {
             %>
             <p>
-                全 <%= jspUtil.attr("totalCount") %> 件中、<%= jspUtil.attr("currentPageStart") %> 件目 〜 <%= jspUtil.attr("currentPageEnd") %> 件目を表示中
+                <%= jspUtil.label("knowledge.list.pagination.current", jspUtil.attr("totalCount"), jspUtil.attr("currentPageStart"), jspUtil.attr("currentPageEnd")) %>
                 <%
                     if (!jspUtil.attr("pinnedCount").equals("0")) {
                 %>
-                （ピン留め記事を <%= jspUtil.attr("pinnedCount") %> 件表示中）
+                <%= jspUtil.label("knowledge.list.pagination.pinned", jspUtil.attr("pinnedCount")) %>
                 <%
                     }
                 %>

--- a/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
@@ -228,15 +228,36 @@
         <!-- Pager -->
         <nav>
             <ul class="pager">
+                <%
+                    if (!jspUtil.attr("offset").equals("0")) {
+                %>
                 <li class="previous"><a
                     href="<%=request.getContextPath()%>/open.knowledge/list/<%=jspUtil.out("previous")%><%=jspUtil.out("params")%>">
                      <span aria-hidden="true">&larr;</span><%=jspUtil.label("label.previous")%>
                 </a></li>
+                <%
+                    }
+                %>
+                <%
+                    if (jspUtil.attr("hasNextPage").equals("true")) {
+                %>
                 <li class="next"><a
                     href="<%=request.getContextPath()%>/open.knowledge/list/<%=jspUtil.out("next")%><%=jspUtil.out("params")%>">
                         <%=jspUtil.label("label.next")%> <span aria-hidden="true">&rarr;</span>
                 </a></li>
+                <%
+                    }
+                %>
             </ul>
+            <%
+                if (!jspUtil.attr("totalCount").equals("0")) {
+            %>
+            <p>
+                全 <%= jspUtil.attr("totalCount") %> 件中、<%= jspUtil.attr("currentPageStart") %> 件目 〜 <%= jspUtil.attr("currentPageEnd") %> 件目を表示中
+            </p>
+            <%
+                }
+            %>
         </nav>
 
         <c:import url="/WEB-INF/views/commons/notice/notice.jsp" />

--- a/src/test/java/org/support/project/knowledge/logic/KnowledgeLogicTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/KnowledgeLogicTest.java
@@ -1,6 +1,6 @@
 package org.support.project.knowledge.logic;
 
-import static org.support.project.common.test.AssertEx.eqdb;
+import static org.support.project.common.test.AssertEx.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +17,7 @@ import org.support.project.knowledge.TestCommon;
 import org.support.project.knowledge.dao.KnowledgesDao;
 import org.support.project.knowledge.entity.KnowledgesEntity;
 import org.support.project.knowledge.vo.KnowledgeData;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.ormapping.common.DBUserPool;
 
 import net.arnx.jsonic.JSON;
@@ -109,7 +110,8 @@ public class KnowledgeLogicTest extends TestCommon {
         ignores.add("score"); // スコアは、Luceneが算出する値なのでテストしない（Luceneの実装が変化すると値が変わるので）
 
         KnowledgeLogic logic = KnowledgeLogic.get();
-        List<KnowledgesEntity> entities = logic.searchKnowledge(null, loginedUser, 0, 100);
+        KnowledgeListInfo knowledgesListInfo = logic.searchKnowledge(null, loginedUser, 0, 100); 
+        List<KnowledgesEntity> entities = knowledgesListInfo.getKnowledgesEntityList();
         LOG.info(JSON.encode(entities, true));
         eqdb(checks, entities, ignores);
 
@@ -118,14 +120,16 @@ public class KnowledgeLogicTest extends TestCommon {
         checks.add(list.get(1)); // スコア上
         checks.add(list.get(0));
 
-        entities = logic.searchKnowledge(null, loginedUser2, 0, 100);
+        knowledgesListInfo = logic.searchKnowledge(null, loginedUser2, 0, 100);
+        entities = knowledgesListInfo.getKnowledgesEntityList();
         LOG.info(JSON.encode(entities, true));
         eqdb(checks, entities, ignores);
 
         checks = new ArrayList<KnowledgesEntity>();
         checks.add(list.get(0));
 
-        entities = logic.searchKnowledge("テスト", loginedUser2, 0, 100);
+        knowledgesListInfo = logic.searchKnowledge("テスト", loginedUser2, 0, 100);
+        entities = knowledgesListInfo.getKnowledgesEntityList();
         list.get(0).setContent("<span class=\"mark\">テスト</span>だよ");
 
         LOG.info(JSON.encode(entities, true));

--- a/src/test/java/org/support/project/knowledge/logic/integration/PostCommentPublicLogicIntegrationTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/integration/PostCommentPublicLogicIntegrationTest.java
@@ -21,6 +21,7 @@ import org.support.project.knowledge.entity.NotifyQueuesEntity;
 import org.support.project.knowledge.logic.KnowledgeLogic;
 import org.support.project.knowledge.logic.MailLogic;
 import org.support.project.knowledge.logic.notification.QueueNotification;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.ormapping.common.DBUserPool;
 import org.support.project.web.bean.LoginedUser;
 import org.support.project.web.dao.MailConfigsDao;
@@ -106,7 +107,8 @@ public class PostCommentPublicLogicIntegrationTest extends TestCommon {
     public void testKnowledgeView() throws Exception {
         LOG.info("記事を参照");
         LoginedUser user = getLoginUser("integration-test-user-01");
-        List<KnowledgesEntity> knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         KnowledgesEntity knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);
@@ -114,7 +116,8 @@ public class PostCommentPublicLogicIntegrationTest extends TestCommon {
         Assert.assertEquals(knowledgeId, knowledge.getKnowledgeId().intValue());
         
         user = getLoginUser("integration-test-user-02");
-        knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);

--- a/src/test/java/org/support/project/knowledge/logic/integration/PostPrivateLogicIntegrationTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/integration/PostPrivateLogicIntegrationTest.java
@@ -22,6 +22,7 @@ import org.support.project.knowledge.entity.NotifyQueuesEntity;
 import org.support.project.knowledge.logic.KnowledgeLogic;
 import org.support.project.knowledge.logic.TemplateLogic;
 import org.support.project.knowledge.logic.notification.QueueNotification;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.ormapping.common.DBUserPool;
 import org.support.project.web.bean.LoginedUser;
 import org.support.project.web.dao.MailConfigsDao;
@@ -170,7 +171,8 @@ public class PostPrivateLogicIntegrationTest extends TestCommon {
     public void testKnowledgeView() throws Exception {
         LOG.info("記事を参照");
         LoginedUser user = getLoginUser("integration-test-user-01");
-        List<KnowledgesEntity> knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         KnowledgesEntity knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);
@@ -178,7 +180,8 @@ public class PostPrivateLogicIntegrationTest extends TestCommon {
         Assert.assertEquals(knowledgeId, knowledge.getKnowledgeId().intValue());
         
         user = getLoginUser("integration-test-user-02");
-        knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(0, knowledges.size()); // 登録者以外は参照できない
     }
     

--- a/src/test/java/org/support/project/knowledge/logic/integration/PostProtectLogicIntegrationTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/integration/PostProtectLogicIntegrationTest.java
@@ -22,6 +22,7 @@ import org.support.project.knowledge.logic.MailLogic;
 import org.support.project.knowledge.logic.TargetLogic;
 import org.support.project.knowledge.logic.TemplateLogic;
 import org.support.project.knowledge.logic.notification.QueueNotification;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.ormapping.common.DBUserPool;
 import org.support.project.web.bean.LoginedUser;
 import org.support.project.web.dao.MailConfigsDao;
@@ -150,7 +151,8 @@ public class PostProtectLogicIntegrationTest extends TestCommon {
     public void testKnowledgeView() throws Exception {
         LOG.info("記事を参照");
         LoginedUser user = getLoginUser("integration-test-user-01");
-        List<KnowledgesEntity> knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         KnowledgesEntity knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);
@@ -158,7 +160,8 @@ public class PostProtectLogicIntegrationTest extends TestCommon {
         Assert.assertEquals(knowledgeId, knowledge.getKnowledgeId().intValue());
         
         user = getLoginUser("integration-test-user-03");
-        knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);
@@ -166,7 +169,8 @@ public class PostProtectLogicIntegrationTest extends TestCommon {
         Assert.assertEquals(knowledgeId, knowledge.getKnowledgeId().intValue());
         
         user = getLoginUser("integration-test-user-02");
-        knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(0, knowledges.size());
     }
     

--- a/src/test/java/org/support/project/knowledge/logic/integration/PostPublicLogicIntegrationTest.java
+++ b/src/test/java/org/support/project/knowledge/logic/integration/PostPublicLogicIntegrationTest.java
@@ -22,6 +22,7 @@ import org.support.project.knowledge.entity.NotifyQueuesEntity;
 import org.support.project.knowledge.logic.KnowledgeLogic;
 import org.support.project.knowledge.logic.MailLogic;
 import org.support.project.knowledge.logic.notification.QueueNotification;
+import org.support.project.knowledge.vo.KnowledgeListInfo;
 import org.support.project.ormapping.common.DBUserPool;
 import org.support.project.web.bean.LoginedUser;
 import org.support.project.web.dao.MailConfigsDao;
@@ -183,7 +184,8 @@ public class PostPublicLogicIntegrationTest extends TestCommon {
     public void testKnowledgeView() throws Exception {
         LOG.info("記事を参照");
         LoginedUser user = getLoginUser("integration-test-user-01");
-        List<KnowledgesEntity> knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        KnowledgeListInfo knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        List<KnowledgesEntity> knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         KnowledgesEntity knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);
@@ -191,7 +193,8 @@ public class PostPublicLogicIntegrationTest extends TestCommon {
         Assert.assertEquals(knowledgeId, knowledge.getKnowledgeId().intValue());
         
         user = getLoginUser("integration-test-user-02");
-        knowledges = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledgesListInfo = KnowledgeLogic.get().searchKnowledge(null, user, 0, 100);
+        knowledges = knowledgesListInfo.getKnowledgesEntityList();
         Assert.assertEquals(1, knowledges.size());
         
         knowledge = KnowledgeLogic.get().select(knowledges.get(0).getKnowledgeId(), user);

--- a/src/test/java/org/support/project/knowledge/searcher/SearchConditionTest.java
+++ b/src/test/java/org/support/project/knowledge/searcher/SearchConditionTest.java
@@ -1,5 +1,10 @@
 package org.support.project.knowledge.searcher;
 
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.Date;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.support.project.common.config.ConfigLoader;
@@ -14,12 +19,6 @@ import org.support.project.knowledge.config.AppConfig;
 import org.support.project.knowledge.indexer.Indexer;
 import org.support.project.knowledge.indexer.IndexingValue;
 import org.support.project.knowledge.logic.TemplateLogic;
-
-import java.io.File;
-import java.util.Date;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class SearchConditionTest {
     /** ログ */
@@ -92,20 +91,20 @@ public class SearchConditionTest {
 
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.addTemplate(TemplateLogic.TYPE_ID_KNOWLEDGE);
-        List<SearchResultValue> results = searcher.search(searchingValue, 1);
-        for (SearchResultValue searchResultValue : results) {
+        SearchResultAggregate results = searcher.search(searchingValue, 1);
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
-        assertEquals(1, results.size());
-        SearchResultValue result = results.get(0);
+        assertEquals(1, results.getResultList().size());
+        SearchResultValue result = results.getResultList().get(0);
         assertEquals(id1, result.getId());
 
         searchingValue.addTemplate(TemplateLogic.TYPE_ID_EVENT);
         results = searcher.search(searchingValue, 1);
-        for (SearchResultValue searchResultValue : results) {
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
-        assertEquals(2, results.size());
+        assertEquals(2, results.getResultList().size());
     }
 
     @Test
@@ -121,12 +120,12 @@ public class SearchConditionTest {
 
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.addCreator(100);
-        List<SearchResultValue> results = searcher.search(searchingValue, 1);
-        for (SearchResultValue searchResultValue : results) {
+        SearchResultAggregate results = searcher.search(searchingValue, 1);
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
-        assertEquals(1, results.size());
-        SearchResultValue result = results.get(0);
+        assertEquals(1, results.getResultList().size());
+        SearchResultValue result = results.getResultList().get(0);
         assertEquals(id1, result.getId());
 
     }

--- a/src/test/java/org/support/project/knowledge/searcher/SearchTest.java
+++ b/src/test/java/org/support/project/knowledge/searcher/SearchTest.java
@@ -1,9 +1,8 @@
 package org.support.project.knowledge.searcher;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.io.File;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -65,14 +64,14 @@ public class SearchTest {
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.setKeyword("Lucene");
         Searcher searcher = Container.getComp(Searcher.class);
-        List<SearchResultValue> results = searcher.search(searchingValue, 1);
+        SearchResultAggregate results = searcher.search(searchingValue, 1);
 
-        for (SearchResultValue searchResultValue : results) {
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
 
-        assertEquals(1, results.size());
-        SearchResultValue result = results.get(0);
+        assertEquals(1, results.getResultList().size());
+        SearchResultValue result = results.getResultList().get(0);
         assertEquals(title, result.getTitle());
         assertEquals(contents, result.getContents());
 
@@ -89,11 +88,11 @@ public class SearchTest {
         indexer.writeIndex(indexingValue);
 
         results = searcher.search(searchingValue, 1);
-        for (SearchResultValue searchResultValue : results) {
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
 
-        assertEquals(2, results.size());
+        assertEquals(2, results.getResultList().size());
     }
 
     @Test
@@ -119,14 +118,14 @@ public class SearchTest {
         searchingValue.addUser(0);
 
         Searcher searcher = Container.getComp(Searcher.class);
-        List<SearchResultValue> results = searcher.search(searchingValue, 1);
+        SearchResultAggregate results = searcher.search(searchingValue, 1);
 
-        for (SearchResultValue searchResultValue : results) {
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
 
-        assertEquals(1, results.size());
-        SearchResultValue result = results.get(0);
+        assertEquals(1, results.getResultList().size());
+        SearchResultValue result = results.getResultList().get(0);
         assertEquals(title, result.getTitle());
         assertEquals(contents, result.getContents());
 
@@ -135,7 +134,7 @@ public class SearchTest {
         searchingValue.setKeyword("Lucene");
         searchingValue.addTag(0);
         results = searcher.search(searchingValue, 1);
-        assertEquals(0, results.size());
+        assertEquals(0, results.getResultList().size());
 
         LOG.info("再度検索（絞り込みなし）");
         searchingValue = new SearchingValue();
@@ -143,10 +142,10 @@ public class SearchTest {
 
         results = searcher.search(searchingValue, 1);
 
-        for (SearchResultValue searchResultValue : results) {
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
-        assertEquals(3, results.size());
+        assertEquals(3, results.getResultList().size());
 
         LOG.info("再度検索 limit/offset");
         searchingValue = new SearchingValue();
@@ -156,10 +155,10 @@ public class SearchTest {
 
         results = searcher.search(searchingValue, 1);
 
-        for (SearchResultValue searchResultValue : results) {
+        for (SearchResultValue searchResultValue : results.getResultList()) {
             LOG.info(PropertyUtil.reflectionToString(searchResultValue));
         }
-        assertEquals(1, results.size());
+        assertEquals(1, results.getResultList().size());
 
     }
 
@@ -185,31 +184,31 @@ public class SearchTest {
         Searcher searcher = Container.getComp(Searcher.class);
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.addUser(1);
-        List<SearchResultValue> results = searcher.search(searchingValue, 1);
-        assertEquals(0, results.size());
+        SearchResultAggregate results = searcher.search(searchingValue, 1);
+        assertEquals(0, results.getResultList().size());
 
         searchingValue = new SearchingValue();
         searchingValue.addUser(100);
         results = searcher.search(searchingValue, 1);
-        assertEquals(1, results.size());
+        assertEquals(1, results.getResultList().size());
 
         searchingValue = new SearchingValue();
         searchingValue.addUser(1);
         searchingValue.addGroup(1);
         results = searcher.search(searchingValue, 1);
-        assertEquals(0, results.size());
+        assertEquals(0, results.getResultList().size());
 
         searchingValue = new SearchingValue();
         searchingValue.addUser(1);
         searchingValue.addGroup(100);
         results = searcher.search(searchingValue, 1);
-        assertEquals(1, results.size());
+        assertEquals(1, results.getResultList().size());
 
         searchingValue = new SearchingValue();
         searchingValue.addUser(100);
         searchingValue.addGroup(1);
         results = searcher.search(searchingValue, 1);
-        assertEquals(1, results.size());
+        assertEquals(1, results.getResultList().size());
     }
 
     
@@ -246,18 +245,18 @@ public class SearchTest {
         Searcher searcher = Container.getComp(Searcher.class);
         SearchingValue searchingValue = new SearchingValue();
         searchingValue.addUser(1);
-        List<SearchResultValue> results = searcher.search(searchingValue, 1);
-        assertEquals(0, results.size());
+        SearchResultAggregate results = searcher.search(searchingValue, 1);
+        assertEquals(0, results.getResultList().size());
 
         searchingValue = new SearchingValue();
         searchingValue.addUser(100);
         results = searcher.search(searchingValue, 1);
-        assertEquals(2, results.size());
+        assertEquals(2, results.getResultList().size());
 
         searchingValue = new SearchingValue();
         searchingValue.addTemplate(1);
         results = searcher.search(searchingValue, 1);
-        assertEquals(1, results.size());
+        assertEquals(1, results.getResultList().size());
     }
     
     


### PR DESCRIPTION
According to the total count of search result and current page number, pagination buttons are shown or hidden.

検索結果総件数と現在のページ番号をもとに、前後のページの有無を判定してページングボタンの表示／非表示を切り替えるようにしました。

お手すきの時にご確認お願いいたします。

メインの記事リストのみ対応しています。その他、タグやストックなども同じような修正が必要になる認識ですが、規模が大きいので追って対応できればと考えています。

修正は既存の処理に影響を与えないように工夫したつもりですが、問題等ありましたら教えていただけますと幸いです。