### PR TITLE
Enable mermaid(Fixes #1103).

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "vue": "2.4.2",
     "html2canvas": "0.4.1",
     "jspdf": "1.3.2",
-    "animate.css": "3.5.2"
+    "animate.css": "3.5.2",
+    "mermaid": "8.9.0"
   },
   "devDependencies": {},
   "resolutions": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ gulp.task('min', function() {
 
 gulp.task('copy', ['copy:bootswatch', 'copy:bootswatch2', 'copy:highlightjs', 'copy:font-awesome', 'copy:flag-icon-css', 
     'copy:html5shiv', 'copy:respond', 'copy:MathJax', 'copy:emoji-parser', 'copy:free-file-icons',
-    'copy:diff2html', 'copy:jsdiff', 'copy:jspdf', 'copy:pdfthema']);
+                   'copy:diff2html', 'copy:jsdiff', 'copy:jspdf', 'copy:pdfthema', 'copy:mermaid']);
 
 gulp.task('copy:bootswatch', function() {
     return gulp.src([
@@ -124,6 +124,12 @@ gulp.task('copy:pdfthema', function() {
         'src/main/webapp/css/presentation-thema/**/*'
     ])
     .pipe(gulp.dest('target/knowledge/css/presentation-thema'));
+});
+gulp.task('copy:mermaid', function() {
+    return gulp.src([
+        'src/main/webapp/bower/mermaid/**/*'
+    ])
+    .pipe(gulp.dest('target/knowledge/bower/mermaid'));
 });
 
 gulp.task('check', function () {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-eslint": "4.0.0",
     "emoji-parser": "0.1.1",
     "emoji-images": "0.1.1",
-    "fs-extra": "*"
+    "fs-extra": "8.1.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,6 @@
                             <arguments>run emoji</arguments>
                         </configuration>
                     </execution>
-                    <!--
                     <execution>
                         <id>gulp</id>
                         <phase>prepare-package</phase>
@@ -386,7 +385,6 @@
                             <arguments>default</arguments>
                         </configuration>
                     </execution>
-                    -->
                 </executions>
             </plugin>
 

--- a/src/main/java/org/support/project/knowledge/logic/MarkdownLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/MarkdownLogic.java
@@ -1,6 +1,7 @@
 package org.support.project.knowledge.logic;
 
 import io.github.gitbucket.markedj.Marked;
+import io.github.gitbucket.markedj.Renderer;
 import io.github.gitbucket.markedj.Options;
 
 import java.io.IOException;
@@ -116,7 +117,23 @@ public class MarkdownLogic {
         options.setHeaderPrefix("markdown-agenda-");
         options.setHeaderIdSequential(true);
 
-        String html = Marked.marked(markdown, options);
+        Renderer renderer =
+            new Renderer(options) {
+                @Override
+                public String code(String code, String lang, boolean escaped){
+                    if(lang.equals("mermaid")) {
+                        StringBuilder sb = new StringBuilder();
+                        sb.append("<div class=\"mermaid\">");
+                        sb.append(code);
+                        sb.append("</div>");
+                        return sb.toString();
+                    } else {
+                        return super.code(code, lang, escaped);
+                    }
+                };
+            };
+
+        String html = Marked.marked(markdown, options, renderer);
         result.setHtml(html);
         result.setParsed(true);
         result.setMarkdown(markdown);

--- a/src/main/java/org/support/project/knowledge/logic/MarkdownLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/MarkdownLogic.java
@@ -121,7 +121,7 @@ public class MarkdownLogic {
             new Renderer(options) {
                 @Override
                 public String code(String code, String lang, boolean escaped){
-                    if(lang.equals("mermaid")) {
+                    if(lang != null && lang.equals("mermaid")) {
                         StringBuilder sb = new StringBuilder();
                         sb.append("<div class=\"mermaid\">");
                         sb.append(code);

--- a/src/main/resources/org/support/project/knowledge/logic/marked.js
+++ b/src/main/resources/org/support/project/knowledge/logic/marked.js
@@ -769,12 +769,18 @@ Renderer.prototype.code = function(code, lang, escaped) {
       + '\n</code></pre>';
   }
 
+  if (lang === "mermaid") {
+    return '<div class="mermaid>"'
+      + code
+      + '\n</div>';
+  }
+
   return '<pre><code class="'
     + this.options.langPrefix
     + escape(lang, true)
     + '">'
     + (escaped ? code : escape(code, true))
-    + '\n</code></pre>\n';
+    + '\n</code></pre>\n' + escape(lang, true);
 };
 
 Renderer.prototype.blockquote = function(quote) {

--- a/src/main/webapp/WEB-INF/views/open/knowledge/partials/partials-view-scripts.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/partials/partials-view-scripts.jsp
@@ -17,6 +17,8 @@ MathJax.Hub.Config({
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML,Safe"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/emoji-parser/main.min.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jspdf/dist/jspdf.min.js"></script>
+<script type="text/javascript" src="<%= request.getContextPath() %>/bower/mermaid/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({startOnLoad:true});</script>
 
 <!-- build:js(src/main/webapp) js/page-knowledge-view.js -->
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/bootstrap-tagsinput/dist/bootstrap-tagsinput.min.js"></script>

--- a/src/main/webapp/WEB-INF/views/open/license/index.jsp
+++ b/src/main/webapp/WEB-INF/views/open/license/index.jsp
@@ -35,7 +35,16 @@ $(document).ready(function(){
         type: 'GET',
         timeout: 10000,
     }).done(function(result, textStatus, xhr) {
-        $('#content').html(marked(result));
+      var renderer = new marked.Renderer();
+      renderer.code = function (code, language) {
+        if(language.match(/^mermaid/)){
+           return '<div class="mermaid">'+code+'</div>';
+        }else{
+           return '<pre><code>' + hljs.highlightAuto(code).value + '</code></pre>';
+        }
+      };
+
+      $('#content').html(marked(result, { renderer: renderer }));
     }).fail(function(xhr, textStatus, error) {
         handleErrorResponse(xhr, textStatus, error);
     });

--- a/src/main/webapp/WEB-INF/views/protect/knowledge/partials/partials-edit-scripts.jsp
+++ b/src/main/webapp/WEB-INF/views/protect/knowledge/partials/partials-edit-scripts.jsp
@@ -17,6 +17,8 @@ MathJax.Hub.Config({
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML,Safe"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/emoji-parser/main.min.js"></script>
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/jspdf/dist/jspdf.min.js"></script>
+<script type="text/javascript" src="<%= request.getContextPath() %>/bower/mermaid/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({startOnLoad:true});</script>
 
 <!-- build:js(src/main/webapp) js/page-knowledge-edit.js -->
 <script type="text/javascript" src="<%= request.getContextPath() %>/bower/bootstrap-tagsinput/dist/bootstrap-tagsinput.min.js"></script>

--- a/src/main/webapp/js/comment.js
+++ b/src/main/webapp/js/comment.js
@@ -21,6 +21,8 @@ $(document).ready(function() {
             '#markdownSamplePreview'
         ).then(function() {
             return processMathJax('#sampleMarkdownText');
+        }).then(function() {
+            return processMermaid();
         });
     });
     
@@ -66,6 +68,8 @@ var preview = function() {
         jqObj.html(html);
         processDecoration(target).then(function() {
             return processMathJax(target);
+        }).then(function() {
+            return processMermaid();
         });
     });
 };

--- a/src/main/webapp/js/knowledge-common.js
+++ b/src/main/webapp/js/knowledge-common.js
@@ -57,6 +57,12 @@ var processMathJax = function(target) {
     });
 };
 
+var processMermaid = function(target) {
+    return new Promise(function(resolve, reject) {
+      mermaid.init();
+      return resolve();
+    });
+};
 
 /**
  * 内部の別の記事へのリンクを生成

--- a/src/main/webapp/js/knowledge-emoji-select.js
+++ b/src/main/webapp/js/knowledge-emoji-select.js
@@ -21,6 +21,8 @@ $(document).ready(function() {
             '#markdownSamplePreview'
         ).then(function() {
             return processMathJax('#sampleMarkdownText');
+        }).then(function() {
+            return processMermaid();
         });
     });
 });

--- a/src/main/webapp/js/knowledge-preview.js
+++ b/src/main/webapp/js/knowledge-preview.js
@@ -10,6 +10,11 @@ var preview = function() {
     ).then(function() {
         return processMathJax('#preview');
     }).then(function() {
+      return new Promise(function(resolve, reject) {
+        mermaid.init();
+        return resolve();
+      });
+    }).then(function() {
         if ($('input[name=typeId]:checked').val() === '-102') {
             // プレゼンテーションのタイプであった場合に、プレゼンテーションを生成する
             return createPresentation($($('#preview').children()[0]));

--- a/src/main/webapp/js/knowledge-view-preview.js
+++ b/src/main/webapp/js/knowledge-view-preview.js
@@ -30,6 +30,8 @@ var preview = function() {
         jqObj.html(html);
         processDecoration(target).then(function() {
             return processMathJax(target);
+        }).then(function() {
+            return processMermaid();
         });
     });
 };
@@ -59,6 +61,8 @@ var previewans = function() {
         jqObj.html(html);
         processDecoration(target).then(function() {
             return processMathJax(target);
+        }).then(function() {
+            return processMermaid();
         });
     });
 };

--- a/src/main/webapp/js/mynotice.js
+++ b/src/main/webapp/js/mynotice.js
@@ -8,6 +8,8 @@ $(document).ready(function() {
     var showNotice = function(notice) {
         parseMarkdown(notice.title, notice.message, '#notice_content_area', '#notice_title_area').then(function() {
             return processMathJax('#notice_content_area');
+        }).then(function() {
+            return processMermaid();
         });
         if (notice.showNextTime) {
             $('#showagain').prop('checked', true);

--- a/src/main/webapp/js/notice-list.js
+++ b/src/main/webapp/js/notice-list.js
@@ -6,6 +6,8 @@ var showNotice = function(idx) {
     shown = idx;
     parseMarkdown(notice.title, notice.message, '#notice_content_area', '#notice_title_area').then(function() {
         return processMathJax('#notice_content_area');
+    }).then(function() {
+        return processMermaid();
     });
     if (notice.showNextTime) {
         $('#showagain').prop('checked', true);


### PR DESCRIPTION
Fixes #1103.

To use mermaid syntax, specify `mermaid` to a code block.

![image](https://user-images.githubusercontent.com/60122040/110261253-c8a4f880-7ff2-11eb-93a5-1b0edafac6bc.png)

This patch also includes https://github.com/support-project/knowledge/pull/1100 to build.
