### PR TITLE
Support tomcat 8.5 and jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,21 @@
             <artifactId>markedj</artifactId>
             <version>1.7.0</version>
         </dependency>
-
+	<dependency>
+    	  <groupId>javax.xml.bind</groupId>
+    	  <artifactId>jaxb-api</artifactId>
+    	  <version>2.3.0</version>
+	</dependency>
+	<dependency>
+    	  <groupId>javax.activation</groupId>
+    	  <artifactId>activation</artifactId>
+    	  <version>1.1</version>
+	</dependency>
+	<dependency>
+	  <groupId>org.glassfish.jaxb</groupId>
+	  <artifactId>jaxb-runtime</artifactId>
+	  <version>2.3.0-b170127.1453</version>
+	</dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -3,7 +3,7 @@
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
                       http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-    version="3.1" metadata-complete="true">
+    version="3.1" metadata-complete="false">
 
     <display-name>knowledge</display-name>
 


### PR DESCRIPTION
Fixes #1079.

In my environment, I can run knowledge on tomcat 8.0 and 8.5 with this patch. Jave version is openjdk-11-jdk-headless:amd64.

Originally, I got two errors on jdk-11, tomcat 8.0, and Ubuntu 18.04.

- (1) `Invalid byte tag in constant pool 19`
  - It looks jdk and tomcat version mismatch.
  - I looked https://www.javaprogramto.com/2015/08/java-8-classformatexception-invalid_21.html and changed web.xml
  - I haven't checked we really need this on tomcat 8.5 and jdk11
- (2) JAXBException and related errors
  - I looked https://stackoverflow.com/questions/51916221/javax-xml-bind-jaxbexception-implementation-of-jaxb-api-has-not-been-found-on-mo, and changed pom.xml.
  
