### PR TITLE
Add unread tab (#1114)

### DIFF
--- a/src/main/java/org/support/project/knowledge/dao/KnowledgesDao.java
+++ b/src/main/java/org/support/project/knowledge/dao/KnowledgesDao.java
@@ -340,4 +340,22 @@ public class KnowledgesDao extends GenKnowledgesDao {
         executeUpdate(sql, point, knowledgeId);
     }
 
+    @Aspect(advice = org.support.project.ormapping.transaction.Transaction.class)
+    public List<Long> getUnreadKnowledgeIds(Integer userId,
+                                            int exclude_public_flag,
+                                            int offset, int limit) {
+        // TODO check protected knowledges
+        String sql = "SELECT knowledge_id FROM KNOWLEDGES "
+            + "WHERE knowledge_id NOT IN (SELECT DISTINCT knowledge_id FROM VIEW_HISTORIES WHERE INSERT_USER = ?) "
+            + "AND public_flag <> ?"
+            + "ORDER BY UPDATE_DATETIME DESC "
+            + "Limit ? offset ? "
+            ;
+        return executeQueryList(sql,
+                                Long.class,
+                                userId,
+                                exclude_public_flag,
+                                limit, offset);
+    }
+
 }

--- a/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
+++ b/src/main/java/org/support/project/knowledge/logic/KnowledgeLogic.java
@@ -991,6 +991,25 @@ public class KnowledgeLogic {
     }
 
     /**
+     * get unread knowledges
+     *
+     * @param user
+     * @param offset
+     * @param limit
+     */
+    public List<Long> getUnreadKnowledgeIds(LoginedUser user,
+                                            int offset,
+                                            int limit) {
+        Integer userId = user.getUserId();
+
+        return KnowledgesDao.get().getUnreadKnowledgeIds(userId,
+                                                         PUBLIC_FLAG_PRIVATE,
+                                                         offset,
+                                                         limit);
+
+    }
+
+    /**
      * ナレッジを取得
      * 
      * @param ids

--- a/src/main/resources/appresource.properties
+++ b/src/main/resources/appresource.properties
@@ -229,6 +229,7 @@ knowledge.list.info.group=Required SignIn
 knowledge.list.kind.list=List
 knowledge.list.kind.stock=Stock
 knowledge.list.kind.history=History
+knowledge.list.kind.history=Unread
 knowledge.list.kind.popular=Popular
 knowledge.list.invalid.keyword=Invalid search keyword
 knowledge.list.link.stock=Link to stock list

--- a/src/main/resources/appresource_ja.properties
+++ b/src/main/resources/appresource_ja.properties
@@ -229,6 +229,7 @@ knowledge.list.info.group=グループ機能はサインインする必要があ
 knowledge.list.kind.list=一覧
 knowledge.list.kind.stock=ストック
 knowledge.list.kind.history=履歴
+knowledge.list.kind.unread=未読
 knowledge.list.kind.popular=人気
 knowledge.list.invalid.keyword=検索のキーワードが不正です
 knowledge.list.link.stock=ストックの一覧へ

--- a/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/list.jsp
@@ -57,6 +57,7 @@
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_popularity"><%=jspUtil.label("knowledge.list.kind.popular")%></a></li>
                 <% if (jspUtil.logined()) { %>
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/stocks"><%= jspUtil.label("knowledge.list.kind.stock") %></a></li>
+                <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_unread"><%=jspUtil.label("knowledge.list.kind.unread")%></a></li>
                 <% } %>
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_history"><%=jspUtil.label("knowledge.list.kind.history")%></a></li>
             </ul>

--- a/src/main/webapp/WEB-INF/views/open/knowledge/show_history.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/show_history.jsp
@@ -31,6 +31,7 @@
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_popularity"><%=jspUtil.label("knowledge.list.kind.popular")%></a></li>
                 <% if (jspUtil.logined()) { %>
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/stocks"><%=jspUtil.label("knowledge.list.kind.stock")%></a></li>
+                <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_unread"><%=jspUtil.label("knowledge.list.kind.unread")%></a></li>
                 <% } %>
                 <li role="presentation" class="active"><a href="<%=request.getContextPath()%>/open.knowledge/show_history"><%=jspUtil.label("knowledge.list.kind.history")%></a></li>
             </ul>

--- a/src/main/webapp/WEB-INF/views/open/knowledge/show_unread.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/show_unread.jsp
@@ -1,5 +1,5 @@
-<%@page pageEncoding="UTF-8" isELIgnored="false" session="false" errorPage="/WEB-INF/views/commons/errors/jsp_error.jsp"%>
 <%@page import="java.util.List"%>
+<%@page pageEncoding="UTF-8" isELIgnored="false" session="false" errorPage="/WEB-INF/views/commons/errors/jsp_error.jsp"%>
 <%@page import="org.support.project.common.util.NumberUtils"%>
 <%@page import="org.support.project.knowledge.logic.KnowledgeLogic"%>
 <%@page import="org.support.project.web.util.JspUtil"%>
@@ -8,7 +8,9 @@
 <%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 
-<% JspUtil jspUtil = new JspUtil(request, pageContext); %>
+<%
+JspUtil jspUtil = new JspUtil(request, pageContext);
+%>
 
 <c:import url="/WEB-INF/views/commons/layout/layoutMain.jsp">
 
@@ -26,21 +28,38 @@
         <div class="row">
             <ul class="nav nav-tabs">
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/list"><%=jspUtil.label("knowledge.list.kind.list")%></a></li>
-                <li role="presentation" class="active"><a href="<%=request.getContextPath()%>/open.knowledge/show_popularity"><%=jspUtil.label("knowledge.list.kind.popular")%></a></li>
+                <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_popularity"><%=jspUtil.label("knowledge.list.kind.popular")%></a></li>
                 <% if (jspUtil.logined()) { %>
-                <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/stocks"><%= jspUtil.label("knowledge.list.kind.stock") %></a></li>
-                <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_unread"><%=jspUtil.label("knowledge.list.kind.unread")%></a></li>
+                    <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/stocks"><%=jspUtil.label("knowledge.list.kind.stock")%></a></li>
+                    <li role="presentation" class="active"><a href="<%=request.getContextPath()%>/open.knowledge/show_unread"><%=jspUtil.label("knowledge.list.kind.unread")%></a></li>
                 <% } %>
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_history"><%=jspUtil.label("knowledge.list.kind.history")%></a></li>
+
             </ul>
         </div>
 
         <!-- リスト -->
         <div class="row" id="knowledgeList">
-            <% request.setAttribute("list_data", jspUtil.getValue("popularities", List.class)); %>
+            <%
+            request.setAttribute("list_data", jspUtil.getValue("unreads", List.class));
+            %>
             <c:import url="/WEB-INF/views/open/knowledge/partials/common_list.jsp" />
             <c:import url="/WEB-INF/views/open/knowledge/partials/common_sub_list.jsp" />
         </div>
+
+        <!-- Pager -->
+        <nav>
+            <ul class="pager">
+                <li class="previous"><a
+                                         href="<%=request.getContextPath()%>/open.knowledge/show_unread/<%=jspUtil.out("previous")%><%=jspUtil.out("params")%>">
+                    <span aria-hidden="true">&larr;</span><%=jspUtil.label("label.previous")%>
+                </a></li>
+                <li class="next"><a
+                                     href="<%=request.getContextPath()%>/open.knowledge/show_unread/<%=jspUtil.out("next")%><%=jspUtil.out("params")%>">
+                    <%=jspUtil.label("label.next")%> <span aria-hidden="true">&rarr;</span>
+                </a></li>
+            </ul>
+        </nav>
 
     </c:param>
 

--- a/src/main/webapp/WEB-INF/views/open/knowledge/stocks.jsp
+++ b/src/main/webapp/WEB-INF/views/open/knowledge/stocks.jsp
@@ -30,6 +30,7 @@
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_popularity"><%=jspUtil.label("knowledge.list.kind.popular")%></a></li>
                 <% if (jspUtil.logined()) { %>
                 <li role="presentation" class="active"><a href="<%=request.getContextPath()%>/open.knowledge/stocks"><%= jspUtil.label("knowledge.list.kind.stock") %></a></li>
+                <li role="presentation" class="active"><a href="<%=request.getContextPath()%>/open.knowledge/show_unread"><%=jspUtil.label("knowledge.list.kind.unread")%></a></li>
                 <% } %>
                 <li role="presentation"><a href="<%=request.getContextPath()%>/open.knowledge/show_history"><%=jspUtil.label("knowledge.list.kind.history")%></a></li>
             </ul>


### PR DESCRIPTION
Fixes #1114 

Add unread tab.

This PR has the following limitations.

For now, unread tab page lists **at most** PAGE_LIMIT(=50) knowledge articles at once.
In extreme cases, no article is shown even if there are some unread articles.

Reason:
- `KnowledgesDao.getUnreadKnowledgeIds` searches unread and non-private knowledges order by update_datetime.
- then filters protected articles.
- If `KnowledgesDao`select 50 unread articles but all of them are protected, no article is shown.

In this case, you need to click "next" button.

We can fix it by changing `SELECT` sentences but I didn't because I feel it's a rare case.